### PR TITLE
Update TimeOutMember.java

### DIFF
--- a/src/main/java/info/itsthesky/disky/elements/effects/TimeOutMember.java
+++ b/src/main/java/info/itsthesky/disky/elements/effects/TimeOutMember.java
@@ -46,10 +46,11 @@ public class TimeOutMember extends SpecificBotEffect {
 
 	@Override
 	public boolean initEffect(Expression[] expressions, int matchedPattern, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
+		this.matchedPattern = matchedPattern;
 		exprMember = (Expression<Member>) expressions[0];
+		if (matchedPattern == 2) return true;
 		exprTime = (Expression<Object>) expressions[1];
 		exprReason = (Expression<String>) expressions[2];
-		this.matchedPattern = matchedPattern;
 		return true;
 	}
 

--- a/src/main/java/info/itsthesky/disky/elements/properties/embeds/EffAddField.java
+++ b/src/main/java/info/itsthesky/disky/elements/properties/embeds/EffAddField.java
@@ -45,7 +45,7 @@ public class EffAddField extends Effect {
             return;
         }
         if (desc.length() > 1024) {
-            DiSky.getErrorHandler().exception(e, new RuntimeException("The value of a field cannot be bigger than 1024 characters. The one you're trying to set is '"+name.length()+"' length!"));
+            DiSky.getErrorHandler().exception(e, new RuntimeException("The value of a field cannot be bigger than 1024 characters. The one you're trying to set is '"+desc.length()+"' length!"));
             return;
         }
 


### PR DESCRIPTION
Fixes `Index 1 out of bounds for length 1` when using the third expression `stop timeout of %member%`