### PR TITLE
Code Cleanup & Fix a server crash!

### DIFF
--- a/src/main/java/info/itsthesky/disky/api/events/DiSkyEvent.java
+++ b/src/main/java/info/itsthesky/disky/api/events/DiSkyEvent.java
@@ -4,6 +4,7 @@ import ch.njol.skript.ScriptLoader;
 import ch.njol.skript.Skript;
 import ch.njol.skript.config.Config;
 import ch.njol.skript.lang.*;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.log.SkriptLogger;
 import info.itsthesky.disky.DiSky;
 import info.itsthesky.disky.core.SkriptUtils;
@@ -81,7 +82,7 @@ public abstract class DiSkyEvent<D extends net.dv8tion.jda.api.events.Event> ext
 
     @Override
      @SuppressWarnings("unchecked")
-    public boolean init(Literal<?> @NotNull [] exprs, int matchedPattern, @NotNull SkriptParser.ParseResult parser) {
+    public boolean init(Literal<?> @NotNull [] exprs, int matchedPattern, @NotNull ParseResult parser) {
         bot = (String) (exprs[0] == null ? null : exprs[0].getSingle());
 
         bukkitClass = (Class<? extends Event>) Arrays.stream(this.getClass().getDeclaredClasses())

--- a/src/main/java/info/itsthesky/disky/api/skript/BaseScope.java
+++ b/src/main/java/info/itsthesky/disky/api/skript/BaseScope.java
@@ -5,6 +5,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.config.Node;
 import ch.njol.skript.config.SectionNode;
 import ch.njol.skript.lang.*;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleLiteral;
 import ch.njol.skript.log.SkriptLogger;
 import ch.njol.skript.util.StringMode;
@@ -31,7 +32,7 @@ public abstract class BaseScope<T> extends SelfRegisteringSkriptEvent {
 
     public abstract @Nullable String validate(@Nullable T parsedEntity);
 
-    public void init(Literal<?> @NotNull [] args, int matchedPattern, @NotNull SkriptParser.ParseResult parseResult, SectionNode node) {};
+    public void init(Literal<?> @NotNull [] args, int matchedPattern, @NotNull ParseResult parseResult, SectionNode node) {};
 
     public String parseEntry(SectionNode node, String key) {
         return parseEntry(node, key, "");
@@ -91,7 +92,7 @@ public abstract class BaseScope<T> extends SelfRegisteringSkriptEvent {
     }
 
     @Override
-    public boolean init(Literal<?> @NotNull [] args, int matchedPattern, @NotNull SkriptParser.ParseResult parseResult) {
+    public boolean init(Literal<?> @NotNull [] args, int matchedPattern, @NotNull ParseResult parseResult) {
         final Node node = SkriptLogger.getNode();
         if (!(node instanceof SectionNode))
             return false;

--- a/src/main/java/info/itsthesky/disky/api/skript/EasyPropertyCondition.java
+++ b/src/main/java/info/itsthesky/disky/api/skript/EasyPropertyCondition.java
@@ -4,7 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.SkriptAPIException;
 import ch.njol.skript.lang.Condition;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
@@ -61,7 +61,7 @@ public abstract class EasyPropertyCondition<T> extends Condition {
     }
 
     @Override
-    public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull SkriptParser.ParseResult parseResult) {
+    public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
         expr = (Expression<? extends T>) exprs[0];
         this.setNegated(matchedPattern == 1);
         return true;

--- a/src/main/java/info/itsthesky/disky/api/skript/MultipleGetterExpression.java
+++ b/src/main/java/info/itsthesky/disky/api/skript/MultipleGetterExpression.java
@@ -2,13 +2,10 @@ package info.itsthesky.disky.api.skript;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.parser.ParserInstance;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
-import info.itsthesky.disky.core.SkriptUtils;
-import net.dv8tion.jda.api.events.GenericEvent;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -38,7 +35,7 @@ public abstract class MultipleGetterExpression<T, E extends Event> extends Simpl
 	}
 
 	@Override
-	public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull SkriptParser.ParseResult parseResult) {
+	public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
 		if (!EasyElement.containsEvent(getEvent())) {
 			Skript.error(getValue() + " cannot be used in a " + ParserInstance.get().getCurrentEventName());
 			return false;

--- a/src/main/java/info/itsthesky/disky/api/skript/MultiplyPropertyExpression.java
+++ b/src/main/java/info/itsthesky/disky/api/skript/MultiplyPropertyExpression.java
@@ -3,7 +3,7 @@ package info.itsthesky.disky.api.skript;
 import ch.njol.skript.Skript;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import org.bukkit.event.Event;
@@ -29,7 +29,7 @@ public abstract class MultiplyPropertyExpression<F, T> extends SimpleExpression<
 
     @Override
     @SuppressWarnings("unchecked")
-    public boolean init(final Expression<?> @NotNull [] expr, final int matchedPattern, final @NotNull Kleenean isDelayed, @NotNull final SkriptParser.ParseResult parseResult) {
+    public boolean init(final Expression<?> @NotNull [] expr, final int matchedPattern, final @NotNull Kleenean isDelayed, @NotNull final ParseResult parseResult) {
         this.expr = (Expression<? extends F>) expr[0];
         return true;
     }

--- a/src/main/java/info/itsthesky/disky/api/skript/ReturningSection.java
+++ b/src/main/java/info/itsthesky/disky/api/skript/ReturningSection.java
@@ -4,6 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer;
 import ch.njol.skript.config.SectionNode;
 import ch.njol.skript.lang.*;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import org.bukkit.event.Event;
@@ -36,7 +37,7 @@ public abstract class ReturningSection<T> extends Section {
 	private Variable<T> variable;
 
 	@Override
-	public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull SkriptParser.ParseResult parseResult, @NotNull SectionNode sectionNode, @NotNull List<TriggerItem> triggerItems) {
+	public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult, @NotNull SectionNode sectionNode, @NotNull List<TriggerItem> triggerItems) {
 		loadOptionalCode(sectionNode);
 		variable = (Variable<T>) exprs[exprs.length - 1];
 		return true;
@@ -61,7 +62,7 @@ public abstract class ReturningSection<T> extends Section {
 		private S section;
 
 		@Override
-		public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull SkriptParser.ParseResult parseResult) {
+		public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
 			section = getParser().getCurrentSection(getSectionClass());
 			return getParser().isCurrentSection(getSectionClass());
 		}

--- a/src/main/java/info/itsthesky/disky/api/skript/SimpleGetterExpression.java
+++ b/src/main/java/info/itsthesky/disky/api/skript/SimpleGetterExpression.java
@@ -1,9 +1,7 @@
 package info.itsthesky.disky.api.skript;
 
-import ch.njol.skript.Skript;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
-import ch.njol.skript.lang.parser.ParserInstance;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import org.bukkit.event.Event;
@@ -35,7 +33,7 @@ public abstract class SimpleGetterExpression<T, E extends Event> extends SimpleE
 	}
 
 	@Override
-	public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull SkriptParser.ParseResult parseResult) {
+	public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
 		return getEvent() == null || EasyElement.containsEvent(getEvent());
 	}
 }

--- a/src/main/java/info/itsthesky/disky/api/skript/WaiterEffect.java
+++ b/src/main/java/info/itsthesky/disky/api/skript/WaiterEffect.java
@@ -3,6 +3,7 @@ package info.itsthesky.disky.api.skript;
 import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer;
 import ch.njol.skript.lang.*;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.parser.ParserInstance;
 import ch.njol.skript.timings.SkriptTimings;
 import ch.njol.skript.variables.Variables;
@@ -28,9 +29,9 @@ public abstract class WaiterEffect<T> extends EasyElement {
     @Nullable protected Variable<T> changedVariable = null;
     private boolean isStopped;
 
-    public abstract boolean initEffect(Expression<?>[] expressions, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult);
+    public abstract boolean initEffect(Expression<?>[] expressions, int i, Kleenean kleenean, ParseResult parseResult);
 
-    public boolean init(Expression<?> @NotNull [] expressions, int i, @NotNull Kleenean kleenean, @NotNull SkriptParser.ParseResult parseResult) {
+    public boolean init(Expression<?> @NotNull [] expressions, int i, @NotNull Kleenean kleenean, @NotNull ParseResult parseResult) {
         ParserInstance.get().setHasDelayBefore(Kleenean.TRUE);
         node = new NodeInformation();
         return initEffect(expressions, i, kleenean, parseResult);

--- a/src/main/java/info/itsthesky/disky/api/skript/action/AbstractNewAction.java
+++ b/src/main/java/info/itsthesky/disky/api/skript/action/AbstractNewAction.java
@@ -1,7 +1,7 @@
 package info.itsthesky.disky.api.skript.action;
 
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.api.skript.EasyElement;
@@ -45,7 +45,7 @@ public abstract class AbstractNewAction<T, E> extends SimpleExpression<T> {
     }
 
     @Override
-    public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull SkriptParser.ParseResult parseResult) {
+    public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
         exprGuild = (Expression<E>) exprs[0];
         exprBot = (Expression<Bot>) exprs[1];
         return true;

--- a/src/main/java/info/itsthesky/disky/api/skript/action/ActionProperty.java
+++ b/src/main/java/info/itsthesky/disky/api/skript/action/ActionProperty.java
@@ -3,7 +3,7 @@ package info.itsthesky.disky.api.skript.action;
 import ch.njol.skript.classes.Changer;
 import ch.njol.skript.config.Node;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.api.changers.ChangeablePropertyExpression;
 import info.itsthesky.disky.api.skript.EasyElement;
@@ -72,7 +72,7 @@ public abstract class ActionProperty<E, T extends AuditableRestAction, O>
     }
 
     @Override
-    public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull SkriptParser.ParseResult parseResult) {
+    public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
         setExpr(exprs[0]);
         node = getParser().getNode();
         return true;

--- a/src/main/java/info/itsthesky/disky/api/skript/action/MultipleActionProperty.java
+++ b/src/main/java/info/itsthesky/disky/api/skript/action/MultipleActionProperty.java
@@ -2,7 +2,7 @@ package info.itsthesky.disky.api.skript.action;
 
 import ch.njol.skript.classes.Changer;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.api.changers.ChangeablePropertyExpression;
 import info.itsthesky.disky.api.skript.EasyElement;
@@ -45,7 +45,7 @@ public abstract class MultipleActionProperty<E, T extends AuditableRestAction<E>
     }
 
     @Override
-    public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull SkriptParser.ParseResult parseResult) {
+    public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
         setExpr(exprs[0]);
         return true;
     }

--- a/src/main/java/info/itsthesky/disky/api/skript/reflects/state/DiSkyStateProperty.java
+++ b/src/main/java/info/itsthesky/disky/api/skript/reflects/state/DiSkyStateProperty.java
@@ -4,7 +4,7 @@ import ch.njol.skript.classes.Changer;
 import ch.njol.skript.config.Node;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.api.skript.INodeHolder;
 import info.itsthesky.disky.elements.changers.IAsyncChangeableExpression;
@@ -18,7 +18,7 @@ public class DiSkyStateProperty extends SimplePropertyExpression<Object, Boolean
     public Node node;
 
     @Override
-    public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+    public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
         node = getParser().getNode();
         return super.init(expressions, matchedPattern, isDelayed, parseResult);
     }

--- a/src/main/java/info/itsthesky/disky/core/SkriptUtils.java
+++ b/src/main/java/info/itsthesky/disky/core/SkriptUtils.java
@@ -5,12 +5,10 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.config.Node;
 import ch.njol.skript.config.SectionNode;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.TriggerItem;
-import ch.njol.skript.lang.VariableString;
 import ch.njol.skript.lang.parser.ParserInstance;
 import ch.njol.skript.lang.util.SimpleExpression;
-import ch.njol.skript.lang.util.SimpleLiteral;
 import ch.njol.skript.log.*;
 import ch.njol.skript.registrations.EventValues;
 import ch.njol.skript.util.*;
@@ -22,14 +20,12 @@ import info.itsthesky.disky.elements.events.ExprEventValues;
 import info.itsthesky.disky.api.events.SimpleDiSkyEvent;
 import info.itsthesky.disky.api.skript.EasyElement;
 import info.itsthesky.disky.elements.effects.RetrieveEventValue;
-import info.itsthesky.disky.elements.events.member.MemberKickEvent;
 import info.itsthesky.disky.elements.sections.handler.DiSkyRuntimeHandler;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Icon;
 import net.dv8tion.jda.api.entities.channel.Channel;
 import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel;
-import net.dv8tion.jda.api.events.guild.GenericGuildEvent;
 import net.dv8tion.jda.api.events.message.GenericMessageEvent;
 import net.dv8tion.jda.api.requests.RestAction;
 import org.bukkit.Bukkit;
@@ -40,7 +36,6 @@ import org.skriptlang.skript.lang.entry.EntryValidator;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;
@@ -133,7 +128,7 @@ public final class SkriptUtils {
                     }
 
                     @Override
-                    public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull SkriptParser.ParseResult parseResult) {
+                    public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
                         return true;
                     }
                 };

--- a/src/main/java/info/itsthesky/disky/elements/BaseBotEffect.java
+++ b/src/main/java/info/itsthesky/disky/elements/BaseBotEffect.java
@@ -5,7 +5,7 @@ import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.Effect;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.DiSky;
 import info.itsthesky.disky.api.skript.SpecificBotEffect;
@@ -31,7 +31,7 @@ public class BaseBotEffect extends WaiterEffect<Object> {
     private SpecificBotEffect<Object> effect;
 
     @Override
-    public boolean initEffect(Expression<?>[] expressions, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
+    public boolean initEffect(Expression<?>[] expressions, int i, Kleenean kleenean, ParseResult parseResult) {
         exprBot = (Expression<Bot>) expressions[0];
         final String rawEffect = parseResult.regexes.get(0).group();
         final Effect unparsedEffect = Effect.parse(rawEffect, "Can't understand this effect: " + rawEffect);

--- a/src/main/java/info/itsthesky/disky/elements/commands/CommandFactory.java
+++ b/src/main/java/info/itsthesky/disky/elements/commands/CommandFactory.java
@@ -6,6 +6,7 @@ import ch.njol.skript.classes.ClassInfo;
 import ch.njol.skript.classes.Parser;
 import ch.njol.skript.config.SectionNode;
 import ch.njol.skript.lang.*;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleLiteral;
 import ch.njol.skript.registrations.Classes;
 import ch.njol.skript.util.StringMode;
@@ -13,10 +14,8 @@ import ch.njol.skript.util.Timespan;
 import ch.njol.skript.util.Utils;
 import ch.njol.util.NonNullPair;
 import ch.njol.util.StringUtils;
-import info.itsthesky.disky.api.DiSkyType;
 import info.itsthesky.disky.core.SkriptUtils;
 import net.dv8tion.jda.api.entities.channel.ChannelType;
-import net.dv8tion.jda.api.requests.RestAction;
 import org.bukkit.event.Event;
 
 import java.lang.reflect.InvocationTargetException;
@@ -61,9 +60,9 @@ public class CommandFactory {
 
     public boolean parseArguments(String args, CommandObject command, Event event) {
         SkriptParser parser = new SkriptParser(args, SkriptParser.PARSE_LITERALS, ParseContext.COMMAND);
-        SkriptParser.ParseResult res = null;
+        ParseResult res = null;
         try {
-            res = (SkriptParser.ParseResult) PARSE_I.invoke(parser, command.getPattern());
+            res = (ParseResult) PARSE_I.invoke(parser, command.getPattern());
         } catch (IllegalAccessException | InvocationTargetException e) {
             e.printStackTrace();
         }

--- a/src/main/java/info/itsthesky/disky/elements/commands/DiSkyCommand.java
+++ b/src/main/java/info/itsthesky/disky/elements/commands/DiSkyCommand.java
@@ -2,7 +2,7 @@ package info.itsthesky.disky.elements.commands;
 
 import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SkriptEvent;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.registrations.EventValues;
 import ch.njol.skript.util.Getter;
 import info.itsthesky.disky.DiSky;
@@ -76,7 +76,7 @@ public class DiSkyCommand extends SkriptEvent {
     }
 
     @Override
-    public boolean init(Literal<?> @NotNull [] exprs, int i, @NotNull SkriptParser.ParseResult parseResult) {
+    public boolean init(Literal<?> @NotNull [] exprs, int i, @NotNull ParseResult parseResult) {
         return true;
     }
 

--- a/src/main/java/info/itsthesky/disky/elements/commands/values/UsedAlias.java
+++ b/src/main/java/info/itsthesky/disky/elements/commands/values/UsedAlias.java
@@ -7,7 +7,7 @@ import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.elements.commands.CommandEvent;
@@ -51,7 +51,7 @@ public class UsedAlias extends SimpleExpression<String> {
     }
 
     @Override
-    public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull SkriptParser.ParseResult parseResult) {
+    public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
         if (!ScriptLoader.isCurrentEvent(CommandEvent.class)) {
             Skript.error("The used alias can only used in a discord command trigger section.");
             return false;

--- a/src/main/java/info/itsthesky/disky/elements/commands/values/UsedArgument.java
+++ b/src/main/java/info/itsthesky/disky/elements/commands/values/UsedArgument.java
@@ -6,7 +6,7 @@ import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.elements.commands.CommandEvent;
@@ -50,7 +50,7 @@ public class UsedArgument extends SimpleExpression<String> {
     }
 
     @Override
-    public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull SkriptParser.ParseResult parseResult) {
+    public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
         if (!ScriptLoader.isCurrentEvent(CommandEvent.class)) {
             Skript.error("The used arguments can only used in a discord command trigger section.");
             return false;

--- a/src/main/java/info/itsthesky/disky/elements/commands/values/UsedPrefix.java
+++ b/src/main/java/info/itsthesky/disky/elements/commands/values/UsedPrefix.java
@@ -7,7 +7,7 @@ import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.elements.commands.CommandEvent;
@@ -50,7 +50,7 @@ public class UsedPrefix extends SimpleExpression<String> {
     }
 
     @Override
-    public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull SkriptParser.ParseResult parseResult) {
+    public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
         if (!ScriptLoader.isCurrentEvent(CommandEvent.class)) {
             Skript.error("The used prefix can only used in a discord command trigger section.");
             return false;

--- a/src/main/java/info/itsthesky/disky/elements/components/commands/EditMessageComponent.java
+++ b/src/main/java/info/itsthesky/disky/elements/components/commands/EditMessageComponent.java
@@ -3,7 +3,7 @@ package info.itsthesky.disky.elements.components.commands;
 import ch.njol.skript.Skript;
 import ch.njol.skript.config.Node;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.AsyncEffect;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.DiSky;
@@ -36,7 +36,7 @@ public class EditMessageComponent extends AsyncEffect {
     private Expression<Object> exprComponent;
 
     @Override
-    public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+    public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
         node = getParser().getNode();
         exprID = (Expression<String>) expressions[0];
         exprMessage = (Expression<Message>) expressions[1];

--- a/src/main/java/info/itsthesky/disky/elements/components/commands/EffEnableDisableCommand.java
+++ b/src/main/java/info/itsthesky/disky/elements/components/commands/EffEnableDisableCommand.java
@@ -5,7 +5,7 @@ import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.api.skript.SpecificBotEffect;
 import info.itsthesky.disky.core.Bot;
@@ -56,7 +56,7 @@ public class EffEnableDisableCommand extends SpecificBotEffect {
 	}
 
 	@Override
-	public boolean initEffect(Expression[] expressions, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
+	public boolean initEffect(Expression[] expressions, int i, Kleenean kleenean, ParseResult parseResult) {
 		isDisable = i == 0;
 		exprCommand = (Expression<SlashCommandData>) expressions[0];
 		if (!isDisable)

--- a/src/main/java/info/itsthesky/disky/elements/components/commands/EffUpdateCommand.java
+++ b/src/main/java/info/itsthesky/disky/elements/components/commands/EffUpdateCommand.java
@@ -2,7 +2,7 @@ package info.itsthesky.disky.elements.components.commands;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.DiSky;
 import info.itsthesky.disky.api.skript.WaiterEffect;
@@ -29,7 +29,7 @@ public class EffUpdateCommand extends WaiterEffect {
 	private Expression<Object> exprEntity;
 
 	@Override
-	public boolean initEffect(Expression[] expressions, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
+	public boolean initEffect(Expression[] expressions, int i, Kleenean kleenean, ParseResult parseResult) {
 		exprCommands = (Expression<SlashCommandData>) expressions[0];
 		exprEntity = (Expression<Object>) expressions[1];
 		isGlobal = (parseResult.mark & 1) != 0;

--- a/src/main/java/info/itsthesky/disky/elements/components/commands/ExprNewMessageCommand.java
+++ b/src/main/java/info/itsthesky/disky/elements/components/commands/ExprNewMessageCommand.java
@@ -6,7 +6,7 @@ import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.api.skript.EasyElement;
@@ -35,7 +35,7 @@ public class ExprNewMessageCommand extends SimpleExpression<CommandData> {
 	private Expression<String> exprName;
 
 	@Override
-	public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull SkriptParser.ParseResult parseResult) {
+	public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
 		exprName = (Expression<String>) exprs[0];
 		return true;
 	}

--- a/src/main/java/info/itsthesky/disky/elements/components/commands/ExprNewOptionChoice.java
+++ b/src/main/java/info/itsthesky/disky/elements/components/commands/ExprNewOptionChoice.java
@@ -6,7 +6,7 @@ import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.api.skript.EasyElement;
@@ -31,7 +31,7 @@ public class ExprNewOptionChoice extends SimpleExpression<Command.Choice> {
 	}
 
 	@Override
-	public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull SkriptParser.ParseResult parseResult) {
+	public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
 		exprName = (Expression<String>) exprs[0];
 		exprValue = (Expression<Object>) exprs[1];
 		return true;

--- a/src/main/java/info/itsthesky/disky/elements/components/commands/ExprNewSlashCommand.java
+++ b/src/main/java/info/itsthesky/disky/elements/components/commands/ExprNewSlashCommand.java
@@ -3,7 +3,7 @@ package info.itsthesky.disky.elements.components.commands;
 import ch.njol.skript.Skript;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.api.skript.EasyElement;
@@ -68,7 +68,7 @@ public class ExprNewSlashCommand extends SimpleExpression<Object> {
 	private boolean isNSFW;
 
 	@Override
-	public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull SkriptParser.ParseResult parseResult) {
+	public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
 		exprName = (Expression<String>) exprs[0];
 		exprDesc = (Expression<String>) exprs[1];
 		type = Type.fromPattern(matchedPattern);

--- a/src/main/java/info/itsthesky/disky/elements/components/commands/ExprNewSlashOption.java
+++ b/src/main/java/info/itsthesky/disky/elements/components/commands/ExprNewSlashOption.java
@@ -3,7 +3,7 @@ package info.itsthesky.disky.elements.components.commands;
 import ch.njol.skript.Skript;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.api.skript.EasyElement;
@@ -30,7 +30,7 @@ public class ExprNewSlashOption extends SimpleExpression<OptionData> {
 	private boolean required, autoComplete, member;
 
 	@Override
-	public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull SkriptParser.ParseResult parseResult) {
+	public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
 		exprType = (Expression<OptionType>) exprs[0];
 		exprName = (Expression<String>) exprs[1];
 		exprDesc = (Expression<String>) exprs[2];

--- a/src/main/java/info/itsthesky/disky/elements/components/commands/ExprNewUserCommand.java
+++ b/src/main/java/info/itsthesky/disky/elements/components/commands/ExprNewUserCommand.java
@@ -6,13 +6,12 @@ import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.api.skript.EasyElement;
 import net.dv8tion.jda.api.interactions.commands.build.CommandData;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
-import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -36,7 +35,7 @@ public class ExprNewUserCommand extends SimpleExpression<CommandData> {
 	private Expression<String> exprName;
 
 	@Override
-	public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull SkriptParser.ParseResult parseResult) {
+	public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
 		exprName = (Expression<String>) exprs[0];
 		return true;
 	}

--- a/src/main/java/info/itsthesky/disky/elements/components/commands/UnregisterCommand.java
+++ b/src/main/java/info/itsthesky/disky/elements/components/commands/UnregisterCommand.java
@@ -5,7 +5,7 @@ import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.DiSky;
 import info.itsthesky.disky.api.skript.SpecificBotEffect;
@@ -39,7 +39,7 @@ public class UnregisterCommand extends SpecificBotEffect {
     private Expression<Object> exprEntity;
 
     @Override
-    public boolean initEffect(Expression[] expressions, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
+    public boolean initEffect(Expression[] expressions, int i, Kleenean kleenean, ParseResult parseResult) {
         exprNames = (Expression<String>) expressions[0];
         exprEntity = (Expression<Object>) expressions[1];
         isGlobal = (parseResult.mark & 1) != 0;

--- a/src/main/java/info/itsthesky/disky/elements/components/create/ExprNewButton.java
+++ b/src/main/java/info/itsthesky/disky/elements/components/create/ExprNewButton.java
@@ -7,13 +7,10 @@ import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.api.emojis.Emote;
-import info.itsthesky.disky.api.skript.EasyElement;
-import info.itsthesky.disky.core.Debug;
-import info.itsthesky.disky.core.JDAUtils;
 import info.itsthesky.disky.elements.sections.handler.DiSkyRuntimeHandler;
 import net.dv8tion.jda.api.entities.SkuSnowflake;
 import net.dv8tion.jda.api.interactions.components.buttons.Button;
@@ -46,7 +43,7 @@ public class ExprNewButton extends SimpleExpression<Button> {
 
     @SuppressWarnings("unchecked")
     @Override
-    public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+    public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, ParseResult parseResult) {
         isPremium = matchedPattern == 1;
         isEnabled = !parseResult.expr.contains("new disabled");
         node = getParser().getNode();

--- a/src/main/java/info/itsthesky/disky/elements/components/create/ExprNewButtonsRow.java
+++ b/src/main/java/info/itsthesky/disky/elements/components/create/ExprNewButtonsRow.java
@@ -5,7 +5,7 @@ import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.elements.components.core.ComponentRow;
@@ -25,7 +25,7 @@ public class ExprNewButtonsRow extends SimpleExpression<ComponentRow> {
 
     @SuppressWarnings("unchecked")
     @Override
-    public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull SkriptParser.ParseResult parseResult) {
+    public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
         return true;
     }
 

--- a/src/main/java/info/itsthesky/disky/elements/components/create/ExprNewDropdown.java
+++ b/src/main/java/info/itsthesky/disky/elements/components/create/ExprNewDropdown.java
@@ -7,16 +7,13 @@ import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.api.skript.EasyElement;
-import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.interactions.components.selections.EntitySelectMenu;
 import net.dv8tion.jda.api.interactions.components.selections.SelectMenu;
 import net.dv8tion.jda.api.interactions.components.selections.StringSelectMenu;
-import net.dv8tion.jda.api.interactions.components.text.TextInput;
-import net.dv8tion.jda.api.interactions.components.text.TextInputStyle;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -56,7 +53,7 @@ public class ExprNewDropdown extends SimpleExpression<SelectMenu.Builder> {
 	private Expression<String> exprTarget;
 
 	@Override
-	public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull SkriptParser.ParseResult parseResult) {
+	public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
 		exprId = (Expression<String>) exprs[0];
 		isEntity = matchedPattern == 1;
 		if (isEntity) exprTarget = (Expression<String>) exprs[1];

--- a/src/main/java/info/itsthesky/disky/elements/components/create/ExprNewDropdownOption.java
+++ b/src/main/java/info/itsthesky/disky/elements/components/create/ExprNewDropdownOption.java
@@ -6,7 +6,7 @@ import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.api.emojis.Emote;
@@ -38,7 +38,7 @@ public class ExprNewDropdownOption extends SimpleExpression<SelectOption> {
 
     @SuppressWarnings("unchecked")
     @Override
-    public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+    public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, ParseResult parseResult) {
         exprValue = (Expression<String>) exprs[0];
         exprName = (Expression<String>) exprs[1];
         exprDesc = (Expression<String>) exprs[2];

--- a/src/main/java/info/itsthesky/disky/elements/components/create/ExprNewInput.java
+++ b/src/main/java/info/itsthesky/disky/elements/components/create/ExprNewInput.java
@@ -3,7 +3,7 @@ package info.itsthesky.disky.elements.components.create;
 import ch.njol.skript.Skript;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.api.skript.EasyElement;
@@ -30,7 +30,7 @@ public class ExprNewInput extends SimpleExpression<TextInput.Builder> {
 	private TextInputStyle style;
 
 	@Override
-	public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull SkriptParser.ParseResult parseResult) {
+	public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
 		exprId = (Expression<String>) exprs[0];
 		exprName = (Expression<String>) exprs[1];
 		style = matchedPattern == 0 ? TextInputStyle.PARAGRAPH : TextInputStyle.SHORT;

--- a/src/main/java/info/itsthesky/disky/elements/components/create/ExprNewModal.java
+++ b/src/main/java/info/itsthesky/disky/elements/components/create/ExprNewModal.java
@@ -3,7 +3,7 @@ package info.itsthesky.disky.elements.components.create;
 import ch.njol.skript.Skript;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.api.skript.EasyElement;
@@ -27,7 +27,7 @@ public class ExprNewModal extends SimpleExpression<Modal.Builder> {
 	private Expression<String> exprName;
 
 	@Override
-	public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull SkriptParser.ParseResult parseResult) {
+	public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
 		exprId = (Expression<String>) exprs[0];
 		exprName = (Expression<String>) exprs[1];
 		return true;

--- a/src/main/java/info/itsthesky/disky/elements/components/properties/ComponentValue.java
+++ b/src/main/java/info/itsthesky/disky/elements/components/properties/ComponentValue.java
@@ -6,7 +6,7 @@ import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.api.skript.EasyElement;
@@ -70,7 +70,7 @@ public class ComponentValue extends SimpleExpression<Object> {
 	private boolean isSingle;
 
 	@Override
-	public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull SkriptParser.ParseResult parseResult) {
+	public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
 		if (!EasyElement.containsEvent(ModalSendEvent.BukkitModalSendEvent.class)) {
 			Skript.error("You can only get values of components in a modal receive event.");
 			return false;

--- a/src/main/java/info/itsthesky/disky/elements/components/properties/ExprNewLocaleData.java
+++ b/src/main/java/info/itsthesky/disky/elements/components/properties/ExprNewLocaleData.java
@@ -6,7 +6,7 @@ import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.api.skript.EasyElement;
@@ -35,7 +35,7 @@ public class ExprNewLocaleData extends SimpleExpression<PropLocalization.LocaleD
 	private Expression<String> exprValue;
 
 	@Override
-	public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull SkriptParser.ParseResult parseResult) {
+	public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
 		exprLocale = (Expression<String>) exprs[0];
 		exprValue = (Expression<String>) exprs[1];
 		return true;

--- a/src/main/java/info/itsthesky/disky/elements/components/properties/PropLocalization.java
+++ b/src/main/java/info/itsthesky/disky/elements/components/properties/PropLocalization.java
@@ -5,7 +5,7 @@ import ch.njol.skript.classes.Changer;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.api.skript.EasyElement;
 import info.itsthesky.disky.api.skript.MultiplyPropertyExpression;
@@ -38,7 +38,7 @@ public class PropLocalization extends MultiplyPropertyExpression<Object, PropLoc
 	private boolean isName;
 
 	@Override
-	public boolean init(Expression<?> @NotNull [] expr, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull SkriptParser.ParseResult parseResult) {
+	public boolean init(Expression<?> @NotNull [] expr, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
 		this.expr = expr[0];
 		isName = parseResult.expr.startsWith("name");
 		return true;

--- a/src/main/java/info/itsthesky/disky/elements/conditions/BotMemberIsInThread.java
+++ b/src/main/java/info/itsthesky/disky/elements/conditions/BotMemberIsInThread.java
@@ -3,7 +3,7 @@ package info.itsthesky.disky.elements.conditions;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.api.skript.EasyPropertyCondition;
 import info.itsthesky.disky.api.skript.PropertyCondition;
@@ -45,7 +45,7 @@ public class BotMemberIsInThread extends EasyPropertyCondition<Object> {
     }
 
     @Override
-    public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull SkriptParser.ParseResult parseResult) {
+    public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
         exprThread = (Expression<ThreadChannel>) exprs[0];
         return super.init(exprs, matchedPattern, isDelayed, parseResult);
     }

--- a/src/main/java/info/itsthesky/disky/elements/conditions/HasRole.java
+++ b/src/main/java/info/itsthesky/disky/elements/conditions/HasRole.java
@@ -4,7 +4,7 @@ import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.api.skript.EasyElement;
 import info.itsthesky.disky.api.skript.EasyPropertyCondition;
@@ -39,7 +39,7 @@ public class HasRole extends EasyPropertyCondition<Member> {
     }
 
     @Override
-    public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull SkriptParser.ParseResult parseResult) {
+    public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
         exprRole = (Expression<Role>) exprs[1];
         return super.init(exprs, matchedPattern, isDelayed, parseResult);
     }

--- a/src/main/java/info/itsthesky/disky/elements/effects/ArchiveUnarchiveThread.java
+++ b/src/main/java/info/itsthesky/disky/elements/effects/ArchiveUnarchiveThread.java
@@ -6,7 +6,7 @@ import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.AsyncEffect;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.DiSky;
@@ -35,7 +35,7 @@ public class ArchiveUnarchiveThread extends AsyncEffect {
 	private boolean archived;
 
 	@Override
-	public boolean init(Expression[] expressions, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
+	public boolean init(Expression[] expressions, int i, Kleenean kleenean, ParseResult parseResult) {
 		getParser().setHasDelayBefore(Kleenean.TRUE);
 
 		exprThread = (Expression<ThreadChannel>) expressions[0];

--- a/src/main/java/info/itsthesky/disky/elements/effects/BanMember.java
+++ b/src/main/java/info/itsthesky/disky/elements/effects/BanMember.java
@@ -6,14 +6,10 @@ import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.AsyncEffect;
 import ch.njol.skript.util.Timespan;
 import ch.njol.util.Kleenean;
-import info.itsthesky.disky.DiSky;
-import info.itsthesky.disky.api.skript.EasyElement;
-import info.itsthesky.disky.api.skript.SpecificBotEffect;
-import info.itsthesky.disky.core.Bot;
 import info.itsthesky.disky.elements.sections.handler.DiSkyRuntimeHandler;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
@@ -49,7 +45,7 @@ public class BanMember extends AsyncEffect {
     private Expression<Guild> exprGuild;
 
     @Override
-    public boolean init(Expression[] expr, int matchedPattern, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
+    public boolean init(Expression[] expr, int matchedPattern, Kleenean kleenean, ParseResult parseResult) {
         getParser().setHasDelayBefore(Kleenean.TRUE);
         usingUserId = matchedPattern == 1;
         node = getParser().getNode();

--- a/src/main/java/info/itsthesky/disky/elements/effects/ConnectBot.java
+++ b/src/main/java/info/itsthesky/disky/elements/effects/ConnectBot.java
@@ -6,7 +6,7 @@ import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.AsyncEffect;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.api.skript.EasyElement;
@@ -46,7 +46,7 @@ public class ConnectBot extends AsyncEffect {
 	private Expression<Guild> exprGuild;
 
 	@Override
-	public boolean init(Expression[] expressions, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
+	public boolean init(Expression[] expressions, int i, Kleenean kleenean, ParseResult parseResult) {
 		getParser().setHasDelayBefore(Kleenean.TRUE);
 
 		exprBot = (Expression<Bot>) expressions[0];

--- a/src/main/java/info/itsthesky/disky/elements/effects/CreateAction.java
+++ b/src/main/java/info/itsthesky/disky/elements/effects/CreateAction.java
@@ -4,13 +4,10 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer;
 import ch.njol.skript.config.Node;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
-import ch.njol.skript.lang.Variable;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.AsyncEffect;
 import ch.njol.util.Kleenean;
-import info.itsthesky.disky.DiSky;
 import info.itsthesky.disky.api.skript.INodeHolder;
-import info.itsthesky.disky.api.skript.WaiterEffect;
 import info.itsthesky.disky.elements.sections.handler.DiSkyRuntimeHandler;
 import net.dv8tion.jda.api.requests.restaction.AuditableRestAction;
 import org.bukkit.event.Event;
@@ -35,7 +32,7 @@ public class CreateAction extends AsyncEffect implements INodeHolder {
     private Node node;
 
     @Override
-    public boolean init(Expression<?>[] expressions, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
+    public boolean init(Expression<?>[] expressions, int i, Kleenean kleenean, ParseResult parseResult) {
         getParser().setHasDelayBefore(Kleenean.TRUE);
         node = getParser().getNode();
 

--- a/src/main/java/info/itsthesky/disky/elements/effects/CreateEmote.java
+++ b/src/main/java/info/itsthesky/disky/elements/effects/CreateEmote.java
@@ -6,14 +6,11 @@ import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
-import ch.njol.skript.lang.Variable;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.AsyncEffect;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.DiSky;
 import info.itsthesky.disky.api.emojis.Emote;
-import info.itsthesky.disky.api.skript.SpecificBotEffect;
-import info.itsthesky.disky.core.Bot;
 import info.itsthesky.disky.core.JDAUtils;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Icon;
@@ -54,7 +51,7 @@ public class CreateEmote extends AsyncEffect {
     }
 
     @Override
-    public boolean init(Expression<?>[] exprs, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
+    public boolean init(Expression<?>[] exprs, int i, Kleenean kleenean, ParseResult parseResult) {
         getParser().setHasDelayBefore(Kleenean.TRUE);
 
         exprName = (Expression<String>) exprs[0];

--- a/src/main/java/info/itsthesky/disky/elements/effects/CreateInvite.java
+++ b/src/main/java/info/itsthesky/disky/elements/effects/CreateInvite.java
@@ -4,19 +4,15 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer;
 import ch.njol.skript.config.Node;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
-import ch.njol.skript.lang.Variable;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.AsyncEffect;
 import ch.njol.skript.util.Timespan;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.DiSky;
-import info.itsthesky.disky.api.skript.SpecificBotEffect;
-import info.itsthesky.disky.core.Bot;
 import info.itsthesky.disky.core.SkriptUtils;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Invite;
 import net.dv8tion.jda.api.entities.channel.attribute.IInviteContainer;
-import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel;
 import net.dv8tion.jda.api.requests.restaction.InviteAction;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
@@ -49,7 +45,7 @@ public class CreateInvite extends AsyncEffect {
     }
 
     @Override
-    public boolean init(Expression<?>[] exprs, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
+    public boolean init(Expression<?>[] exprs, int i, Kleenean kleenean, ParseResult parseResult) {
         getParser().setHasDelayBefore(Kleenean.TRUE);
 
         exprEntity = (Expression<Object>) exprs[0];

--- a/src/main/java/info/itsthesky/disky/elements/effects/CreatePost.java
+++ b/src/main/java/info/itsthesky/disky/elements/effects/CreatePost.java
@@ -7,7 +7,7 @@ import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.AsyncEffect;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.DiSky;
@@ -52,7 +52,7 @@ public class CreatePost extends AsyncEffect {
 	private Expression<Object> exprResult;
 
 	@Override
-	public boolean init(Expression<?>[] expressions, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
+	public boolean init(Expression<?>[] expressions, int i, Kleenean kleenean, ParseResult parseResult) {
 		getParser().setHasDelayBefore(Kleenean.TRUE);
 
 		exprChannel = (Expression<ForumChannel>) expressions[0];

--- a/src/main/java/info/itsthesky/disky/elements/effects/CreateScheduledEvent.java
+++ b/src/main/java/info/itsthesky/disky/elements/effects/CreateScheduledEvent.java
@@ -6,7 +6,7 @@ import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.AsyncEffect;
 import ch.njol.skript.util.Date;
 import ch.njol.util.Kleenean;
@@ -55,7 +55,7 @@ public class CreateScheduledEvent extends AsyncEffect {
 	private boolean isPlace = false;
 
 	@Override
-	public boolean init(Expression<?>[] expressions, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
+	public boolean init(Expression<?>[] expressions, int i, Kleenean kleenean, ParseResult parseResult) {
 		getParser().setHasDelayBefore(Kleenean.TRUE);
 
 		isPlace = i == 1;

--- a/src/main/java/info/itsthesky/disky/elements/effects/CreateThread.java
+++ b/src/main/java/info/itsthesky/disky/elements/effects/CreateThread.java
@@ -5,8 +5,7 @@ import ch.njol.skript.classes.Changer;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
-import ch.njol.skript.lang.Variable;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.AsyncEffect;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.DiSky;
@@ -49,7 +48,7 @@ public class CreateThread extends AsyncEffect {
     }
 
     @Override
-    public boolean init(Expression<?>[] exprs, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
+    public boolean init(Expression<?>[] exprs, int i, Kleenean kleenean, ParseResult parseResult) {
         getParser().setHasDelayBefore(Kleenean.TRUE);
 
         exprName = (Expression<String>) exprs[0];

--- a/src/main/java/info/itsthesky/disky/elements/effects/DeferInteraction.java
+++ b/src/main/java/info/itsthesky/disky/elements/effects/DeferInteraction.java
@@ -5,17 +5,15 @@ import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.AsyncEffect;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.DiSky;
 import info.itsthesky.disky.api.events.specific.InteractionEvent;
 import info.itsthesky.disky.api.skript.EasyElement;
-import info.itsthesky.disky.api.skript.WaiterEffect;
 import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
 import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.component.GenericComponentInteractionCreateEvent;
-import net.dv8tion.jda.api.interactions.InteractionHook;
 import net.dv8tion.jda.api.interactions.callbacks.IReplyCallback;
 import net.dv8tion.jda.api.interactions.components.ComponentInteraction;
 import org.bukkit.event.Event;
@@ -49,7 +47,7 @@ public class DeferInteraction extends AsyncEffect {
     private boolean shouldwait;
 
     @Override
-    public boolean init(Expression[] expressions, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
+    public boolean init(Expression[] expressions, int i, Kleenean kleenean, ParseResult parseResult) {
         getParser().setHasDelayBefore(Kleenean.TRUE);
 
         if (!EasyElement.containsInterfaces(InteractionEvent.class)) {

--- a/src/main/java/info/itsthesky/disky/elements/effects/DestroyEntity.java
+++ b/src/main/java/info/itsthesky/disky/elements/effects/DestroyEntity.java
@@ -6,7 +6,7 @@ import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.AsyncEffect;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.DiSky;
@@ -43,7 +43,7 @@ public class DestroyEntity extends AsyncEffect {
 	private Node node;
 
 	@Override
-	public boolean init(Expression[] expressions, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
+	public boolean init(Expression[] expressions, int i, Kleenean kleenean, ParseResult parseResult) {
 		getParser().setHasDelayBefore(Kleenean.TRUE);
 		node = getParser().getNode();
 

--- a/src/main/java/info/itsthesky/disky/elements/effects/EditMessage.java
+++ b/src/main/java/info/itsthesky/disky/elements/effects/EditMessage.java
@@ -7,7 +7,7 @@ import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.AsyncEffect;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.DiSky;
@@ -51,7 +51,7 @@ public class EditMessage extends AsyncEffect {
 	private Node node;
 
 	@Override
-	public boolean init(Expression[] expressions, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
+	public boolean init(Expression[] expressions, int i, Kleenean kleenean, ParseResult parseResult) {
 		getParser().setHasDelayBefore(Kleenean.TRUE);
 
 		exprTarget = (Expression<Object>) expressions[0];

--- a/src/main/java/info/itsthesky/disky/elements/effects/KickMember.java
+++ b/src/main/java/info/itsthesky/disky/elements/effects/KickMember.java
@@ -5,12 +5,10 @@ import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.AsyncEffect;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.DiSky;
-import info.itsthesky.disky.api.skript.SpecificBotEffect;
-import info.itsthesky.disky.core.Bot;
 import net.dv8tion.jda.api.entities.Member;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
@@ -34,7 +32,7 @@ public class KickMember extends AsyncEffect {
     private Expression<String> exprReason;
 
     @Override
-    public boolean init(Expression @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull SkriptParser.ParseResult parseResult) {
+    public boolean init(Expression @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
         getParser().setHasDelayBefore(Kleenean.TRUE);
 
         exprMember = (Expression<Member>) exprs[0];

--- a/src/main/java/info/itsthesky/disky/elements/effects/LoadMembers.java
+++ b/src/main/java/info/itsthesky/disky/elements/effects/LoadMembers.java
@@ -7,7 +7,7 @@ import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.AsyncEffect;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.DiSky;
@@ -40,7 +40,7 @@ public class LoadMembers extends AsyncEffect {
 	private Expression<Object> exprResult;
 
 	@Override
-	public boolean init(Expression<?>[] expressions, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
+	public boolean init(Expression<?>[] expressions, int i, Kleenean kleenean, ParseResult parseResult) {
 		getParser().setHasDelayBefore(Kleenean.TRUE);
 
 		exprGuild = (Expression<Guild>) expressions[0];

--- a/src/main/java/info/itsthesky/disky/elements/effects/LockUnlockThread.java
+++ b/src/main/java/info/itsthesky/disky/elements/effects/LockUnlockThread.java
@@ -6,7 +6,7 @@ import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.AsyncEffect;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.DiSky;
@@ -37,7 +37,7 @@ public class LockUnlockThread extends AsyncEffect {
 	private boolean lock;
 
 	@Override
-	public boolean init(Expression[] expressions, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
+	public boolean init(Expression[] expressions, int i, Kleenean kleenean, ParseResult parseResult) {
 		getParser().setHasDelayBefore(Kleenean.TRUE);
 
 		exprThread = expressions[0];

--- a/src/main/java/info/itsthesky/disky/elements/effects/MakeBotLeave.java
+++ b/src/main/java/info/itsthesky/disky/elements/effects/MakeBotLeave.java
@@ -2,7 +2,7 @@ package info.itsthesky.disky.elements.effects;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.AsyncEffect;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.DiSky;
@@ -24,7 +24,7 @@ public class MakeBotLeave extends AsyncEffect {
     private Expression<Guild> exprGuild;
 
     @Override
-    public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+    public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
         exprBot = (Expression<Bot>) expressions[0];
         exprGuild = (Expression<Guild>) expressions[1];
         return true;

--- a/src/main/java/info/itsthesky/disky/elements/effects/MoveMember.java
+++ b/src/main/java/info/itsthesky/disky/elements/effects/MoveMember.java
@@ -5,7 +5,7 @@ import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.AsyncEffect;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.DiSky;
@@ -37,7 +37,7 @@ public class MoveMember extends AsyncEffect {
     private boolean isDisconnect = false;
 
     @Override
-    public boolean init(Expression[] exprs, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
+    public boolean init(Expression[] exprs, int i, Kleenean kleenean, ParseResult parseResult) {
         getParser().setHasDelayBefore(Kleenean.TRUE);
         isDisconnect = i == 1;
 

--- a/src/main/java/info/itsthesky/disky/elements/effects/MoveRole.java
+++ b/src/main/java/info/itsthesky/disky/elements/effects/MoveRole.java
@@ -5,7 +5,7 @@ import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.AsyncEffect;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.DiSky;
@@ -36,7 +36,7 @@ public class MoveRole extends AsyncEffect {
 	private boolean isAbove;
 
 	@Override
-	public boolean init(Expression[] expressions, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
+	public boolean init(Expression[] expressions, int i, Kleenean kleenean, ParseResult parseResult) {
 		getParser().setHasDelayBefore(Kleenean.TRUE);
 
 		exprTarget = (Expression<Role>) expressions[0];

--- a/src/main/java/info/itsthesky/disky/elements/effects/MuteMember.java
+++ b/src/main/java/info/itsthesky/disky/elements/effects/MuteMember.java
@@ -5,12 +5,10 @@ import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.AsyncEffect;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.DiSky;
-import info.itsthesky.disky.api.skript.SpecificBotEffect;
-import info.itsthesky.disky.core.Bot;
 import net.dv8tion.jda.api.entities.Member;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
@@ -37,7 +35,7 @@ public class MuteMember extends AsyncEffect {
     private int matchedPattern;
 
     @Override
-    public boolean init(Expression[] expr, int matchedPattern, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
+    public boolean init(Expression[] expr, int matchedPattern, Kleenean kleenean, ParseResult parseResult) {
         getParser().setHasDelayBefore(Kleenean.TRUE);
 
         exprMember = (Expression<Member>) expr[0];

--- a/src/main/java/info/itsthesky/disky/elements/effects/OpenPrivateChannel.java
+++ b/src/main/java/info/itsthesky/disky/elements/effects/OpenPrivateChannel.java
@@ -6,17 +6,12 @@ import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.AsyncEffect;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.DiSky;
-import info.itsthesky.disky.api.skript.SpecificBotEffect;
-import info.itsthesky.disky.core.Bot;
-import info.itsthesky.disky.core.Utils;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel;
-import net.dv8tion.jda.api.requests.RestAction;
-import net.dv8tion.jda.api.requests.restaction.CacheRestAction;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -42,7 +37,7 @@ public class OpenPrivateChannel extends AsyncEffect {
     private Expression<Object> exprResult;
 
     @Override
-    public boolean init(Expression<?>[] exprs, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
+    public boolean init(Expression<?>[] exprs, int i, Kleenean kleenean, ParseResult parseResult) {
         getParser().setHasDelayBefore(Kleenean.TRUE);
 
         exprUser = (Expression<User>) exprs[0];

--- a/src/main/java/info/itsthesky/disky/elements/effects/PinMessage.java
+++ b/src/main/java/info/itsthesky/disky/elements/effects/PinMessage.java
@@ -3,7 +3,7 @@ package info.itsthesky.disky.elements.effects;
 import ch.njol.skript.Skript;
 import ch.njol.skript.config.Node;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.AsyncEffect;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.DiSky;
@@ -28,7 +28,7 @@ public class PinMessage extends AsyncEffect {
     private Expression<Message> exprMessage;
 
     @Override
-    public boolean init(Expression<?>[] expressions, int matchedPattern, @NotNull Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+    public boolean init(Expression<?>[] expressions, int matchedPattern, @NotNull Kleenean isDelayed, ParseResult parseResult) {
         getParser().setHasDelayBefore(Kleenean.TRUE);
 
         node = getParser().getNode();

--- a/src/main/java/info/itsthesky/disky/elements/effects/PostMessage.java
+++ b/src/main/java/info/itsthesky/disky/elements/effects/PostMessage.java
@@ -8,7 +8,7 @@ import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.AsyncEffect;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.core.Bot;
@@ -52,7 +52,7 @@ public class PostMessage extends AsyncEffect {
 	private Node node;
 
 	@Override
-	public boolean init(Expression<?>[] expressions, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
+	public boolean init(Expression<?>[] expressions, int i, Kleenean kleenean, ParseResult parseResult) {
 		getParser().setHasDelayBefore(Kleenean.TRUE);
 		node = getParser().getNode();
 

--- a/src/main/java/info/itsthesky/disky/elements/effects/PublishMessage.java
+++ b/src/main/java/info/itsthesky/disky/elements/effects/PublishMessage.java
@@ -2,7 +2,7 @@ package info.itsthesky.disky.elements.effects;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.DiSky;
 import info.itsthesky.disky.api.skript.SpecificBotEffect;
@@ -24,7 +24,7 @@ public class PublishMessage extends SpecificBotEffect {
     private Expression<Message> exprMessage;
 
     @Override
-    public boolean initEffect(Expression @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull SkriptParser.ParseResult parseResult) {
+    public boolean initEffect(Expression @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
         exprMessage = (Expression<Message>) exprs[0];
         return true;
     }

--- a/src/main/java/info/itsthesky/disky/elements/effects/PurgeMessages.java
+++ b/src/main/java/info/itsthesky/disky/elements/effects/PurgeMessages.java
@@ -5,7 +5,7 @@ import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.api.skript.SpecificBotEffect;
 import info.itsthesky.disky.core.Bot;
@@ -52,7 +52,7 @@ public class PurgeMessages extends SpecificBotEffect {
     }
 
     @Override
-    public boolean initEffect(Expression[] expressions, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
+    public boolean initEffect(Expression[] expressions, int i, Kleenean kleenean, ParseResult parseResult) {
         exprMessages = (Expression<Message>) expressions[0];
         return true;
     }

--- a/src/main/java/info/itsthesky/disky/elements/effects/ReplyWith.java
+++ b/src/main/java/info/itsthesky/disky/elements/effects/ReplyWith.java
@@ -1,17 +1,15 @@
 package info.itsthesky.disky.elements.effects;
 
-import ch.njol.skript.ScriptLoader;
 import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer;
 import ch.njol.skript.config.Node;
 import ch.njol.skript.config.SectionNode;
-import ch.njol.skript.config.validate.SectionValidator;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.TriggerItem;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.DiSky;
@@ -29,10 +27,6 @@ import net.dv8tion.jda.api.interactions.Interaction;
 import net.dv8tion.jda.api.interactions.InteractionHook;
 import net.dv8tion.jda.api.interactions.callbacks.IPremiumRequiredReplyCallback;
 import net.dv8tion.jda.api.interactions.callbacks.IReplyCallback;
-import net.dv8tion.jda.api.interactions.components.ActionRow;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
-import net.dv8tion.jda.api.interactions.components.selections.SelectMenu;
-import net.dv8tion.jda.api.interactions.components.text.TextInput;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.MessageCreateAction;
 import net.dv8tion.jda.api.utils.messages.*;
@@ -94,7 +88,7 @@ public class ReplyWith extends AsyncEffectSection {
 	//endregion
 
 	@Override
-	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult, SectionNode sectionNode, List<TriggerItem> triggerItems) {
+	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, ParseResult parseResult, SectionNode sectionNode, List<TriggerItem> triggerItems) {
 		if (!containsInterfaces(MessageEvent.class)) {
 			Skript.error("The effect reply effect can only be used in a message event.");
 			return false;

--- a/src/main/java/info/itsthesky/disky/elements/effects/RetrieveEventValue.java
+++ b/src/main/java/info/itsthesky/disky/elements/effects/RetrieveEventValue.java
@@ -2,7 +2,7 @@ package info.itsthesky.disky.elements.effects;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.parser.ParserInstance;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.DiSky;
@@ -36,7 +36,7 @@ public class RetrieveEventValue extends WaiterEffect<Object> {
 	private String id;
 
 	@Override
-	public boolean initEffect(Expression<?>[] exprs, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
+	public boolean initEffect(Expression<?>[] exprs, int i, Kleenean kleenean, ParseResult parseResult) {
 		final String rawId;
 		try {
 			rawId = ((Expression<String>) exprs[0]).getSingle(null);

--- a/src/main/java/info/itsthesky/disky/elements/effects/SendTyping.java
+++ b/src/main/java/info/itsthesky/disky/elements/effects/SendTyping.java
@@ -5,7 +5,7 @@ import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.DiSky;
 import info.itsthesky.disky.api.skript.SpecificBotEffect;
@@ -32,7 +32,7 @@ public class SendTyping extends SpecificBotEffect {
     private Expression<Channel> exprChannel;
 
     @Override
-    public boolean initEffect(Expression[] expr, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
+    public boolean initEffect(Expression[] expr, int i, Kleenean kleenean, ParseResult parseResult) {
         exprChannel = (Expression<Channel>) expr[0];
         return true;
     }

--- a/src/main/java/info/itsthesky/disky/elements/effects/StopBot.java
+++ b/src/main/java/info/itsthesky/disky/elements/effects/StopBot.java
@@ -5,9 +5,8 @@ import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
-import info.itsthesky.disky.DiSky;
 import info.itsthesky.disky.api.skript.WaiterEffect;
 import info.itsthesky.disky.core.Bot;
 import org.bukkit.event.Event;
@@ -34,7 +33,7 @@ public class StopBot extends WaiterEffect {
 	boolean force;
 
 	@Override
-	public boolean initEffect(Expression[] expressions, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
+	public boolean initEffect(Expression[] expressions, int i, Kleenean kleenean, ParseResult parseResult) {
 		exprBot = (Expression<Bot>) expressions[0];
 		force = parseResult.expr.contains("force");
 		return true;

--- a/src/main/java/info/itsthesky/disky/elements/effects/SuppressReaction.java
+++ b/src/main/java/info/itsthesky/disky/elements/effects/SuppressReaction.java
@@ -6,7 +6,7 @@ import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.DiSky;
 import info.itsthesky.disky.api.emojis.Emote;
@@ -43,7 +43,7 @@ public class SuppressReaction extends SpecificBotEffect {
 	private Expression<Message> exprMessage;
 
 	@Override
-	public boolean initEffect(Expression[] expressions, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
+	public boolean initEffect(Expression[] expressions, int i, Kleenean kleenean, ParseResult parseResult) {
 		exprEmote = (Expression<Emote>) expressions[0];
 		exprUser = (Expression<User>) expressions[1];
 		exprMessage = (Expression<Message>) expressions[2];

--- a/src/main/java/info/itsthesky/disky/elements/effects/TimeOutMember.java
+++ b/src/main/java/info/itsthesky/disky/elements/effects/TimeOutMember.java
@@ -5,7 +5,7 @@ import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.Date;
 import ch.njol.skript.util.Timespan;
 import ch.njol.util.Kleenean;
@@ -45,7 +45,7 @@ public class TimeOutMember extends SpecificBotEffect {
 	private int matchedPattern;
 
 	@Override
-	public boolean initEffect(Expression[] expressions, int matchedPattern, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
+	public boolean initEffect(Expression[] expressions, int matchedPattern, Kleenean kleenean, ParseResult parseResult) {
 		this.matchedPattern = matchedPattern;
 		exprMember = (Expression<Member>) expressions[0];
 		if (matchedPattern == 2) return true;

--- a/src/main/java/info/itsthesky/disky/elements/effects/UnbanMember.java
+++ b/src/main/java/info/itsthesky/disky/elements/effects/UnbanMember.java
@@ -6,6 +6,7 @@ import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.DiSky;
 import info.itsthesky.disky.api.skript.SpecificBotEffect;
@@ -33,7 +34,7 @@ public class UnbanMember extends SpecificBotEffect {
     private Expression<Guild> exprGuild;
 
     @Override
-    public boolean initEffect(Expression[] expr, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
+    public boolean initEffect(Expression[] expr, int i, Kleenean kleenean, ParseResult parseResult) {
         exprUser = (Expression<User>) expr[0];
         exprGuild = (Expression<Guild>) expr[1];
         return true;

--- a/src/main/java/info/itsthesky/disky/elements/effects/retrieve/RetrieveEmotes.java
+++ b/src/main/java/info/itsthesky/disky/elements/effects/retrieve/RetrieveEmotes.java
@@ -3,7 +3,7 @@ package info.itsthesky.disky.elements.effects.retrieve;
 import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.AsyncEffect;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.DiSky;
@@ -30,7 +30,7 @@ public class RetrieveEmotes extends AsyncEffect {
     private Expression<Object> exprResult;
 
     @Override
-    public boolean init(Expression<?>[] expressions, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
+    public boolean init(Expression<?>[] expressions, int i, Kleenean kleenean, ParseResult parseResult) {
         getParser().setHasDelayBefore(Kleenean.TRUE);
 
         exprGuild = (Expression<Guild>) expressions[0];

--- a/src/main/java/info/itsthesky/disky/elements/effects/retrieve/RetrieveInterestedMembers.java
+++ b/src/main/java/info/itsthesky/disky/elements/effects/retrieve/RetrieveInterestedMembers.java
@@ -4,16 +4,14 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.AsyncEffect;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.DiSky;
 import info.itsthesky.disky.core.Bot;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.ScheduledEvent;
-import net.dv8tion.jda.api.requests.RestAction;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
 
@@ -35,7 +33,7 @@ public class RetrieveInterestedMembers extends AsyncEffect {
 	private Expression<Object> exprResult;
 
 	@Override
-	public boolean init(Expression<?>[] expressions, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
+	public boolean init(Expression<?>[] expressions, int i, Kleenean kleenean, ParseResult parseResult) {
 		getParser().setHasDelayBefore(Kleenean.TRUE);
 
 		exprEvent = (Expression<ScheduledEvent>) expressions[0];

--- a/src/main/java/info/itsthesky/disky/elements/effects/retrieve/RetrieveMessages.java
+++ b/src/main/java/info/itsthesky/disky/elements/effects/retrieve/RetrieveMessages.java
@@ -6,12 +6,10 @@ import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.AsyncEffect;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.DiSky;
-import info.itsthesky.disky.api.skript.SpecificBotEffect;
-import info.itsthesky.disky.core.Bot;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import org.bukkit.event.Event;
@@ -39,7 +37,7 @@ public class RetrieveMessages extends AsyncEffect {
     private Expression<Object> exprResult;
 
     @Override
-    public boolean init(Expression<?>[] expressions, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
+    public boolean init(Expression<?>[] expressions, int i, Kleenean kleenean, ParseResult parseResult) {
         getParser().setHasDelayBefore(Kleenean.TRUE);
 
         exprAmount = (Expression<Number>) expressions[0];

--- a/src/main/java/info/itsthesky/disky/elements/effects/retrieve/RetrieveThreadMessage.java
+++ b/src/main/java/info/itsthesky/disky/elements/effects/retrieve/RetrieveThreadMessage.java
@@ -3,7 +3,7 @@ package info.itsthesky.disky.elements.effects.retrieve;
 import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.AsyncEffect;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.DiSky;
@@ -27,7 +27,7 @@ public class RetrieveThreadMessage extends AsyncEffect {
     private boolean start = false;
 
     @Override
-    public boolean init(Expression<?>[] expressions, int matchedPattern, @NotNull Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+    public boolean init(Expression<?>[] expressions, int matchedPattern, @NotNull Kleenean isDelayed, ParseResult parseResult) {
         exprThread = (Expression<ThreadChannel>) expressions[0];
         exprResult = (Expression<Object>) expressions[1];
         start = parseResult.hasTag("start");

--- a/src/main/java/info/itsthesky/disky/elements/events/DiSkyErrorEvent.java
+++ b/src/main/java/info/itsthesky/disky/elements/events/DiSkyErrorEvent.java
@@ -3,7 +3,7 @@ package info.itsthesky.disky.elements.events;
 import ch.njol.skript.Skript;
 import ch.njol.skript.lang.Literal;
 import ch.njol.skript.lang.SelfRegisteringSkriptEvent;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.Trigger;
 import info.itsthesky.disky.api.events.BukkitEvent;
 import info.itsthesky.disky.core.SkriptUtils;
@@ -35,7 +35,7 @@ public class DiSkyErrorEvent extends SelfRegisteringSkriptEvent {
 	public void unregisterAll() {}
 
 	@Override
-	public boolean init(Literal<?> @NotNull [] args, int matchedPattern, @NotNull SkriptParser.ParseResult parseResult) {
+	public boolean init(Literal<?> @NotNull [] args, int matchedPattern, @NotNull ParseResult parseResult) {
 		return true;
 	}
 

--- a/src/main/java/info/itsthesky/disky/elements/events/interactions/SlashCommandReceiveEvent.java
+++ b/src/main/java/info/itsthesky/disky/elements/events/interactions/SlashCommandReceiveEvent.java
@@ -6,7 +6,7 @@ import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.api.events.DiSkyEvent;
 import info.itsthesky.disky.api.events.SimpleDiSkyEvent;
@@ -17,8 +17,6 @@ import info.itsthesky.disky.api.skript.SimpleGetterExpression;
 import info.itsthesky.disky.core.JDAUtils;
 import info.itsthesky.disky.core.SkriptUtils;
 import net.dv8tion.jda.api.entities.*;
-import net.dv8tion.jda.api.entities.channel.*;
-import net.dv8tion.jda.api.entities.channel.attribute.*;
 import net.dv8tion.jda.api.entities.channel.middleman.*;
 import net.dv8tion.jda.api.entities.channel.concrete.*;
 import net.dv8tion.jda.api.events.interaction.GenericInteractionCreateEvent;
@@ -92,7 +90,7 @@ public class SlashCommandReceiveEvent extends DiSkyEvent<SlashCommandInteraction
 
 		@Override
 		@SuppressWarnings("ALL")
-		public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull SkriptParser.ParseResult parseResult) {
+		public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
 			if (!super.init(exprs, matchedPattern, isDelayed, parseResult))
 				return false;
 

--- a/src/main/java/info/itsthesky/disky/elements/events/interactions/SlashCompletionEvent.java
+++ b/src/main/java/info/itsthesky/disky/elements/events/interactions/SlashCompletionEvent.java
@@ -5,6 +5,7 @@ import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.*;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.sections.SecLoop;
 import ch.njol.skript.sections.SecWhile;
 import ch.njol.util.Kleenean;
@@ -16,8 +17,6 @@ import info.itsthesky.disky.api.skript.SimpleGetterExpression;
 import info.itsthesky.disky.core.JDAUtils;
 import info.itsthesky.disky.core.SkriptUtils;
 import net.dv8tion.jda.api.entities.*;
-import net.dv8tion.jda.api.entities.channel.*;
-import net.dv8tion.jda.api.entities.channel.attribute.*;
 import net.dv8tion.jda.api.entities.channel.middleman.*;
 import net.dv8tion.jda.api.entities.channel.concrete.*;
 import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion;
@@ -111,7 +110,7 @@ public class SlashCompletionEvent extends DiSkyEvent<CommandAutoCompleteInteract
 		}
 
 		@Override
-		public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull SkriptParser.ParseResult parseResult) {
+		public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
 			if (!EasyElement.containsEvent(BukkitSlashCompletionEvent.class))
 				return false;
 			exprChoices = (Expression<Command.Choice>) exprs[0];
@@ -178,7 +177,7 @@ public class SlashCompletionEvent extends DiSkyEvent<CommandAutoCompleteInteract
 
 		@Override
 		@SuppressWarnings("ALL")
-		public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull SkriptParser.ParseResult parseResult) {
+		public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
 			if (!super.init(exprs, matchedPattern, isDelayed, parseResult))
 				return false;
 

--- a/src/main/java/info/itsthesky/disky/elements/getters/BaseGetterExpression.java
+++ b/src/main/java/info/itsthesky/disky/elements/getters/BaseGetterExpression.java
@@ -4,10 +4,9 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.config.Node;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
-import info.itsthesky.disky.DiSky;
 import info.itsthesky.disky.api.skript.EasyElement;
 import info.itsthesky.disky.core.Bot;
 import info.itsthesky.disky.core.SkriptUtils;
@@ -46,7 +45,7 @@ public abstract class BaseGetterExpression<T> extends SimpleExpression<T> implem
     };
 
     @Override
-    public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull SkriptParser.ParseResult parseResult) {
+    public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
         exprId = (Expression<String>) exprs[0];
         exprBot = (Expression<Bot>) exprs[1];
         node = getParser().getNode();

--- a/src/main/java/info/itsthesky/disky/elements/getters/ColorFromHex.java
+++ b/src/main/java/info/itsthesky/disky/elements/getters/ColorFromHex.java
@@ -6,7 +6,7 @@ import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.skript.util.Color;
 import ch.njol.skript.util.ColorRGB;
@@ -30,7 +30,7 @@ public class ColorFromHex extends SimpleExpression<Color> {
     private Expression<String> exprHex;
 
     @Override
-    public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull SkriptParser.ParseResult parseResult) {
+    public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
         exprHex = (Expression<String>) exprs[0];
         return true;
     }

--- a/src/main/java/info/itsthesky/disky/elements/getters/ExprEmoji.java
+++ b/src/main/java/info/itsthesky/disky/elements/getters/ExprEmoji.java
@@ -7,7 +7,7 @@ import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.DiSky;
@@ -154,7 +154,7 @@ public class ExprEmoji extends SimpleExpression<Emote> implements IAsyncGettable
 
     @SuppressWarnings("unchecked")
     @Override
-    public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull SkriptParser.ParseResult parseResult) {
+    public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
         name = (Expression<String>) exprs[0];
         guild = (Expression<Guild>) exprs[1];
         node = getParser().getNode();

--- a/src/main/java/info/itsthesky/disky/elements/getters/GetBot.java
+++ b/src/main/java/info/itsthesky/disky/elements/getters/GetBot.java
@@ -6,13 +6,11 @@ import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.DiSky;
 import info.itsthesky.disky.core.Bot;
-import info.itsthesky.disky.managers.BotManager;
-import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -37,7 +35,7 @@ public class GetBot extends SimpleExpression<Bot> {
     private Expression<String> exprName;
 
     @Override
-    public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull SkriptParser.ParseResult parseResult) {
+    public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
         exprName = (Expression<String>) exprs[0];
         return true;
     }

--- a/src/main/java/info/itsthesky/disky/elements/getters/GetMember.java
+++ b/src/main/java/info/itsthesky/disky/elements/getters/GetMember.java
@@ -6,7 +6,7 @@ import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.DiSky;
@@ -39,7 +39,7 @@ public class GetMember extends SimpleExpression<Member> implements IAsyncGettabl
     private Expression<Guild> exprGuild;
 
     @Override
-    public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull SkriptParser.ParseResult parseResult) {
+    public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
         exprId = (Expression<String>) exprs[0];
         exprGuild = (Expression<Guild>) exprs[1];
         return true;

--- a/src/main/java/info/itsthesky/disky/elements/getters/GetSticker.java
+++ b/src/main/java/info/itsthesky/disky/elements/getters/GetSticker.java
@@ -6,13 +6,12 @@ import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.api.skript.EasyElement;
 import info.itsthesky.disky.elements.changers.IAsyncGettableExpression;
 import net.dv8tion.jda.api.entities.Guild;
-import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.sticker.GuildSticker;
 import net.dv8tion.jda.api.entities.sticker.Sticker;
 import org.bukkit.event.Event;
@@ -43,7 +42,7 @@ public class GetSticker extends SimpleExpression<Sticker> implements IAsyncGetta
     private Expression<Guild> exprGuild;
 
     @Override
-    public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull SkriptParser.ParseResult parseResult) {
+    public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
         exprId = (Expression<String>) exprs[0];
         exprGuild = (Expression<Guild>) exprs[1];
         return true;

--- a/src/main/java/info/itsthesky/disky/elements/getters/GetUserInGuild.java
+++ b/src/main/java/info/itsthesky/disky/elements/getters/GetUserInGuild.java
@@ -5,7 +5,7 @@ import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.api.skript.EasyElement;
@@ -32,7 +32,7 @@ public class GetUserInGuild extends SimpleExpression<Member> implements IAsyncGe
 	}
 
 	@Override
-	public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull SkriptParser.ParseResult parseResult) {
+	public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
 		exprUser = (Expression<User>) exprs[0];
 		exprGuild = (Expression<Guild>) exprs[1];
 		return true;

--- a/src/main/java/info/itsthesky/disky/elements/getters/LastDiSkyException.java
+++ b/src/main/java/info/itsthesky/disky/elements/getters/LastDiSkyException.java
@@ -6,7 +6,7 @@ import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.DiSky;
@@ -54,7 +54,7 @@ public class LastDiSkyException extends SimpleExpression<String> {
 	}
 
 	@Override
-	public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull SkriptParser.ParseResult parseResult) {
+	public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
 		return true;
 	}
 }

--- a/src/main/java/info/itsthesky/disky/elements/sections/EmbedSection.java
+++ b/src/main/java/info/itsthesky/disky/elements/sections/EmbedSection.java
@@ -1,19 +1,16 @@
 package info.itsthesky.disky.elements.sections;
 
-import ch.njol.skript.Skript;
 import ch.njol.skript.config.SectionNode;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.*;
-import ch.njol.skript.lang.parser.ParserInstance;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.api.EmbedManager;
 import info.itsthesky.disky.api.skript.ReturningSection;
-import info.itsthesky.disky.elements.sections.message.CreateMessage;
 import net.dv8tion.jda.api.EmbedBuilder;
-import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
 
@@ -77,7 +74,7 @@ public class EmbedSection extends ReturningSection<EmbedBuilder> {
     public boolean init(Expression<?>[] exprs,
                         int matchedPattern,
                         @NotNull Kleenean isDelayed,
-                        @NotNull SkriptParser.ParseResult parseResult,
+                        @NotNull ParseResult parseResult,
                         @Nullable SectionNode sectionNode,
                         @Nullable List<TriggerItem> triggerItems) {
         exprID = (Expression<String>) exprs[0];

--- a/src/main/java/info/itsthesky/disky/elements/sections/FindMemberSection.java
+++ b/src/main/java/info/itsthesky/disky/elements/sections/FindMemberSection.java
@@ -5,8 +5,8 @@ import ch.njol.skript.classes.Changer;
 import ch.njol.skript.classes.ClassInfo;
 import ch.njol.skript.config.SectionNode;
 import ch.njol.skript.effects.Delay;
-import ch.njol.skript.effects.EffReturn;
 import ch.njol.skript.lang.*;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.function.FunctionEvent;
 import ch.njol.skript.lang.function.Functions;
 import ch.njol.skript.lang.function.ScriptFunction;
@@ -17,7 +17,6 @@ import ch.njol.skript.variables.Variables;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.DiSky;
 import info.itsthesky.disky.api.ReflectionUtils;
-import info.itsthesky.disky.core.SkriptUtils;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
 import org.bukkit.Bukkit;
@@ -60,7 +59,7 @@ public class FindMemberSection extends Section {
     private boolean iterationResult = false;
 
     @Override
-    public boolean init(Expression<?>[] expressions, int matchedPattern, @NotNull Kleenean isDelayed, SkriptParser.@NotNull ParseResult parseResult, @NotNull SectionNode sectionNode, @NotNull List<TriggerItem> triggerItems) {
+    public boolean init(Expression<?>[] expressions, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult, @NotNull SectionNode sectionNode, @NotNull List<TriggerItem> triggerItems) {
         exprGuild = (Expression<Guild>) expressions[0];
         exprResult = (Expression<Object>) expressions[1];
         exprValue = (Expression<Object>) expressions[2];
@@ -160,7 +159,7 @@ public class FindMemberSection extends Section {
 
         @SuppressWarnings("unchecked")
         @Override
-        public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+        public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
             if (instance != null) {
                 section = instance;
                 value = exprs[0];

--- a/src/main/java/info/itsthesky/disky/elements/sections/ReactSection.java
+++ b/src/main/java/info/itsthesky/disky/elements/sections/ReactSection.java
@@ -3,6 +3,7 @@ package info.itsthesky.disky.elements.sections;
 import ch.njol.skript.Skript;
 import ch.njol.skript.config.SectionNode;
 import ch.njol.skript.lang.*;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.api.emojis.Emote;
 import info.itsthesky.disky.api.skript.EasyElement;
@@ -36,7 +37,7 @@ public class ReactSection extends EffectSection {
 	public boolean init(Expression<?> @NotNull [] exprs,
 						int matchedPattern,
 						@NotNull Kleenean isDelayed,
-						@NotNull SkriptParser.ParseResult parseResult,
+						@NotNull ParseResult parseResult,
 						@Nullable SectionNode sectionNode,
 						@Nullable List<TriggerItem> triggerItems) {
 		exprMessage = (Expression<Message>) exprs[0];

--- a/src/main/java/info/itsthesky/disky/elements/sections/automod/AutomodResponse.java
+++ b/src/main/java/info/itsthesky/disky/elements/sections/automod/AutomodResponse.java
@@ -3,23 +3,15 @@ package info.itsthesky.disky.elements.sections.automod;
 import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
-import info.itsthesky.disky.DiSky;
 import info.itsthesky.disky.api.skript.EasyElement;
 import info.itsthesky.disky.api.skript.MultiplyPropertyExpression;
 import info.itsthesky.disky.managers.wrappers.AutoModRuleBuilder;
 import net.dv8tion.jda.api.entities.automod.AutoModResponse;
-import net.dv8tion.jda.api.utils.FileUpload;
-import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
 
-import javax.imageio.ImageIO;
-import java.awt.image.BufferedImage;
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -35,7 +27,7 @@ public class AutomodResponse extends MultiplyPropertyExpression<AutoModRuleBuild
 	}
 
 	@Override
-	public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull SkriptParser.ParseResult parseResult) {
+	public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
 		if (!getParser().isCurrentSection(CreateAutoMod.class)) {
 			Skript.error("You can only use the 'automod rule responses' expression inside a 'create auto mod rule' section");
 			return false;

--- a/src/main/java/info/itsthesky/disky/elements/sections/automod/AutomodType.java
+++ b/src/main/java/info/itsthesky/disky/elements/sections/automod/AutomodType.java
@@ -2,17 +2,13 @@ package info.itsthesky.disky.elements.sections.automod;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer;
-import ch.njol.skript.doc.Description;
-import ch.njol.skript.doc.Name;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.api.skript.EasyElement;
-import info.itsthesky.disky.elements.sections.message.CreateMessage;
 import info.itsthesky.disky.managers.wrappers.AutoModRuleBuilder;
 import net.dv8tion.jda.api.entities.automod.build.AutoModRuleData;
-import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -29,7 +25,7 @@ public class AutomodType extends SimplePropertyExpression<AutoModRuleBuilder, Au
 	}
 
 	@Override
-	public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull SkriptParser.ParseResult parseResult) {
+	public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
 		if (!getParser().isCurrentSection(CreateAutoMod.class)) {
 			Skript.error("You can only use the 'rule type' expression inside a 'create auto mod rule' section");
 			return false;

--- a/src/main/java/info/itsthesky/disky/elements/sections/automod/CreateRule.java
+++ b/src/main/java/info/itsthesky/disky/elements/sections/automod/CreateRule.java
@@ -2,7 +2,7 @@ package info.itsthesky.disky.elements.sections.automod;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.api.skript.SpecificBotEffect;
 import info.itsthesky.disky.core.Bot;
@@ -25,7 +25,7 @@ public class CreateRule extends SpecificBotEffect {
 	private Expression<Guild> exprGuild;
 
 	@Override
-	public boolean initEffect(Expression[] expressions, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
+	public boolean initEffect(Expression[] expressions, int i, Kleenean kleenean, ParseResult parseResult) {
 		exprRule = (Expression<AutoModRuleBuilder>) expressions[0];
 		exprGuild = (Expression<Guild>) expressions[1];
 		return true;

--- a/src/main/java/info/itsthesky/disky/elements/sections/message/InlineMessageBuilder.java
+++ b/src/main/java/info/itsthesky/disky/elements/sections/message/InlineMessageBuilder.java
@@ -7,7 +7,7 @@ import ch.njol.skript.doc.Name;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.api.skript.EasyElement;
@@ -58,7 +58,7 @@ public class InlineMessageBuilder extends SimpleExpression<MessageCreateBuilder>
 	private boolean isSilent;
 
 	@Override
-	public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull SkriptParser.ParseResult parseResult) {
+	public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
 		isComponentOnly = matchedPattern == 1;
 		isSilent = parseResult.hasTag("silent");
 		exprBase = (Expression<Object>) exprs[0];

--- a/src/main/java/info/itsthesky/disky/elements/sections/message/MessageAttachments.java
+++ b/src/main/java/info/itsthesky/disky/elements/sections/message/MessageAttachments.java
@@ -5,14 +5,14 @@ import ch.njol.skript.classes.Changer;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.DiSky;
 import info.itsthesky.disky.api.skript.EasyElement;
 import info.itsthesky.disky.api.skript.MultiplyPropertyExpression;
 import net.dv8tion.jda.api.utils.FileUpload;
 import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder;
-import net.dv8tion.jda.api.utils.messages.MessageEditBuilder;
+
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
 
@@ -40,7 +40,7 @@ public class MessageAttachments extends MultiplyPropertyExpression<MessageCreate
 	}
 
 	@Override
-	public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull SkriptParser.ParseResult parseResult) {
+	public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
 		if (!getParser().isCurrentSection(CreateMessage.class)) {
 			Skript.error("You can only use the 'message attachments' expression inside a 'create message' section");
 			return false;

--- a/src/main/java/info/itsthesky/disky/elements/sections/message/MessageContent.java
+++ b/src/main/java/info/itsthesky/disky/elements/sections/message/MessageContent.java
@@ -6,7 +6,7 @@ import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.api.skript.EasyElement;
 import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder;
@@ -29,7 +29,7 @@ public class MessageContent extends SimplePropertyExpression<MessageCreateBuilde
 	}
 
 	@Override
-	public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull SkriptParser.ParseResult parseResult) {
+	public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
 		if (!getParser().isCurrentSection(CreateMessage.class)) {
 			Skript.error("You can only use the 'builder content' expression inside a 'create message' section");
 			return false;

--- a/src/main/java/info/itsthesky/disky/elements/sections/message/MessageEmbeds.java
+++ b/src/main/java/info/itsthesky/disky/elements/sections/message/MessageEmbeds.java
@@ -5,22 +5,16 @@ import ch.njol.skript.classes.Changer;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
 import info.itsthesky.disky.api.skript.EasyElement;
 import info.itsthesky.disky.api.skript.MultiplyPropertyExpression;
-import info.itsthesky.disky.elements.components.core.ComponentRow;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.MessageEmbed;
-import net.dv8tion.jda.api.interactions.components.ActionRow;
-import net.dv8tion.jda.api.interactions.components.LayoutComponent;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
-import net.dv8tion.jda.api.interactions.components.selections.SelectMenu;
 import net.dv8tion.jda.api.utils.messages.MessageCreateBuilder;
 import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -40,7 +34,7 @@ public class MessageEmbeds extends MultiplyPropertyExpression<MessageCreateBuild
 	}
 
 	@Override
-	public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull SkriptParser.ParseResult parseResult) {
+	public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
 		if (!getParser().isCurrentSection(CreateMessage.class)) {
 			Skript.error("You can only use the 'message embeds' expression inside a 'create message' section");
 			return false;

--- a/src/main/java/info/itsthesky/disky/elements/sections/once/ExprSubEventExpression.java
+++ b/src/main/java/info/itsthesky/disky/elements/sections/once/ExprSubEventExpression.java
@@ -8,7 +8,7 @@ import ch.njol.skript.expressions.base.WrapperExpression;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.Literal;
-import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.util.Getter;
 import ch.njol.skript.util.Utils;
 import ch.njol.util.Kleenean;
@@ -33,7 +33,7 @@ public class ExprSubEventExpression extends WrapperExpression<Object> {
 
     @Override
     @SuppressWarnings("unchecked")
-    public boolean init(Expression<?>[] exprs, int matchedPattern, @NotNull Kleenean isDelayed, SkriptParser.ParseResult parser) {
+    public boolean init(Expression<?>[] exprs, int matchedPattern, @NotNull Kleenean isDelayed, ParseResult parser) {
         secListenOnce = getParser().getCurrentSection(SecListenOnce.class);
         if (secListenOnce == null) {
             Skript.error("The 'outer event' expression can only be used in a 'listen once' section.");

--- a/src/main/resources/emojis.json
+++ b/src/main/resources/emojis.json
@@ -14901,6 +14901,14 @@
         "fleur_de_lis"
       ],
       "supportsFitzpatrick": false
+    },
+    {
+      "subpage": "pink-heart",
+      "unicode": "\uD83E\uDE77",
+      "shortcodes": [
+        "pink_heart"
+      ],
+      "supportsFitzpatrick": false
     }
   ]
 }


### PR DESCRIPTION
This PR simply cleans up the code by removing unused imports and use `ParseResult parseResult` and not `SkriptParser.ParseResult parseResult`. This PR also fixes an issue with Pink Heart emoji causing servers to crash.