### PR TITLE
Add thread support to webhooks

### DIFF
--- a/src/main/java/net/itsthesky/disky/elements/effects/DestroyEntity.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/DestroyEntity.java
@@ -14,7 +14,6 @@ import net.itsthesky.disky.api.emojis.Emote;
 import net.itsthesky.disky.api.events.specific.InteractionEvent;
 import net.itsthesky.disky.elements.sections.handler.DiSkyRuntimeHandler;
 import net.itsthesky.disky.managers.wrappers.RegisteredWebhook;
-import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.entities.Webhook;
@@ -65,7 +64,7 @@ public class DestroyEntity extends AsyncEffect {
 					DiSky.getWebhooksManager().getWebhookById(message.getAuthor().getId());
 			if (webhook != null) {
 				DiSky.debug("Deleting message with webhook");
-				action = webhook.getClient().deleteMessageById(message.getId());
+				action = webhook.client().deleteMessageById(message.getId()).setThreadId(webhook.threadId());
 			} else {
 				DiSky.debug("Deleting message without webhook");
 				action = message.delete();

--- a/src/main/java/net/itsthesky/disky/elements/effects/EditMessage.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/EditMessage.java
@@ -112,7 +112,7 @@ public class EditMessage extends AsyncEffect {
 				if (authorWebhook == null) {
 					((Message) target).editMessage(editBuilder.build()).complete();
 				} else {
-					authorWebhook.getClient().editMessageById(targetMsg.getId(), editBuilder.build()).complete();
+					authorWebhook.client().editMessageById(targetMsg.getId(), editBuilder.build()).setThreadId(authorWebhook.threadId()).complete();
 				}
 			}
 		} catch (Exception ex) {

--- a/src/main/java/net/itsthesky/disky/elements/effects/webhooks/MakeClientSpeak.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/webhooks/MakeClientSpeak.java
@@ -71,7 +71,7 @@ public class MakeClientSpeak extends AsyncEffect {
             builder = new MessageCreateBuilder().setContent((String) message);
 
         final RegisteredWebhook registerClient = DiSky.getWebhooksManager().getWebhook(name);
-        final WebhookClient<Message> client = registerClient.getClient();
+        final WebhookClient<Message> client = registerClient.client();
 
         final Message resultMessage;
         try {
@@ -79,6 +79,7 @@ public class MakeClientSpeak extends AsyncEffect {
             resultMessage = client.sendMessage(builder.build())
                     .setUsername(username)
                     .setAvatarUrl(avatar)
+                    .setThreadId(registerClient.threadId())
                     .complete();
 
         } catch (Exception ex) {

--- a/src/main/java/net/itsthesky/disky/elements/effects/webhooks/RegisterClient.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/webhooks/RegisterClient.java
@@ -18,7 +18,7 @@ public class RegisterClient extends Effect {
     static {
         Skript.registerEffect(
                 RegisterClient.class,
-                "register [a] [new] webhook[s] [client] (in|using) [the] [bot] %bot% (with [the] name|named) %string% (and|with) [the] [webhook] url %string%"
+                "register [a] [new] webhook[s] [client] (in|using) [the] [bot] %bot% (with [the] name|named) %string% (and|with) [the] [webhook] url %string% [for thread with id %-string%]"
         );
     }
 
@@ -26,12 +26,14 @@ public class RegisterClient extends Effect {
     private Expression<Bot> exprBot;
     private Expression<String> exprName;
     private Expression<String> exprURL;
+    private Expression<String> exprThreadId;
 
     @Override
     public boolean init(Expression<?> @NotNull [] expressions, int matchedPattern, @NotNull Kleenean isDelayed, SkriptParser.@NotNull ParseResult parseResult) {
         exprBot = (Expression<Bot>) expressions[0];
         exprName = (Expression<String>) expressions[1];
         exprURL = (Expression<String>) expressions[2];
+        exprThreadId = (Expression<String>) expressions[3];
         node = getParser().getNode();
         return true;
     }
@@ -41,6 +43,7 @@ public class RegisterClient extends Effect {
         final Bot bot = exprBot.getSingle(event);
         final String name = exprName.getSingle(event);
         final String url = exprURL.getSingle(event);
+        final String threadId = exprThreadId == null ? null : exprThreadId.getSingle(event);
         if (bot == null || name == null || url == null)
             return;
 
@@ -49,11 +52,13 @@ public class RegisterClient extends Effect {
             return;
         }
 
-        DiSky.getWebhooksManager().registerWebhook(bot, name, url);
+        DiSky.getWebhooksManager().registerWebhook(bot, name, url, threadId);
     }
 
     @Override
     public @NotNull String toString(@Nullable Event event, boolean debug) {
+        if (exprThreadId != null)
+            return "register a new webhook client in bot " + exprBot.toString(event, debug) + " with name " + exprName.toString(event, debug) + " and url " + exprURL.toString(event, debug) + " for thread with id " + exprThreadId.toString(event, debug);
         return "register a new webhook client in bot " + exprBot.toString(event, debug) + " with name " + exprName.toString(event, debug) + " and url " + exprURL.toString(event, debug);
     }
 }

--- a/src/main/java/net/itsthesky/disky/managers/WebhooksManager.java
+++ b/src/main/java/net/itsthesky/disky/managers/WebhooksManager.java
@@ -26,9 +26,9 @@ public final class WebhooksManager {
         this.webhooks = new HashMap<>();
     }
 
-    public void registerWebhook(Bot bot, String name, String url) {
+    public void registerWebhook(Bot bot, String name, String url, @Nullable String threadId) {
         final WebhookClient<Message> client = WebhookClient.createClient(bot.getInstance(), url);
-        final RegisteredWebhook webhook = new RegisteredWebhook(name, bot, client);
+        final RegisteredWebhook webhook = new RegisteredWebhook(name, bot, client, threadId);
 
         webhooks.put(name, webhook);
     }
@@ -51,7 +51,7 @@ public final class WebhooksManager {
     public @Nullable RegisteredWebhook getWebhookById(String id) {
         return webhooks.values()
                 .stream()
-                .filter(webhook -> webhook.getClient().getId().equals(id))
+                .filter(webhook -> webhook.client().getId().equals(id))
                 .findFirst().orElse(null);
     }
 

--- a/src/main/java/net/itsthesky/disky/managers/wrappers/RegisteredWebhook.java
+++ b/src/main/java/net/itsthesky/disky/managers/wrappers/RegisteredWebhook.java
@@ -3,31 +3,14 @@ package net.itsthesky.disky.managers.wrappers;
 import net.itsthesky.disky.core.Bot;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.WebhookClient;
+import org.jetbrains.annotations.Nullable;
 
 /**
- * Pair a {@link net.dv8tion.jda.api.entities.WebhookClient webhooks client} with a {@link Bot bot}
+ * Pairs a {@link net.dv8tion.jda.api.entities.WebhookClient webhooks client} with a {@link Bot bot}.
+ *
+ * @param name The name the client is referenced by.
+ * @param bot The bot this client will be paired with.
+ * @param client The {@link WebhookClient} that is being paired with.
+ * @param threadId An optional id of a thread, that you want this webhook to send to
  */
-public class RegisteredWebhook {
-
-    private final String name;
-    private final Bot bot;
-    private final WebhookClient<Message> client;
-
-    public RegisteredWebhook(String name, Bot bot, WebhookClient<Message> client) {
-        this.name = name;
-        this.bot = bot;
-        this.client = client;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public Bot getBot() {
-        return bot;
-    }
-
-    public WebhookClient<Message> getClient() {
-        return client;
-    }
-}
+public record RegisteredWebhook(String name, Bot bot, WebhookClient<Message> client, @Nullable String threadId) { }


### PR DESCRIPTION
This PR came from a necessity, since we're unable to use the `?thread_id=...` on webhook urls as developers we had no way to send messages to a thread with a webhook.

This PR is simple, basically only adds a new parameter for `threadId`, and updates the `RegisteredWebhook` class to use a record, there doesn't appear to be any reason to not already have this working as a record.

EDIT: if you were to ever permit a change to how webhooks are handled, I'd be more than happy to take that venture, as this only supports existing threads not creating a new thread completely.

<img width="1485" height="714" alt="image" src="https://github.com/user-attachments/assets/52dab32c-f064-47f2-a652-edcde492fbb7" />
