### PR TITLE
Spelling correction in `RetrieveMember.java`

### DIFF
--- a/src/main/java/net/itsthesky/disky/elements/effects/retrieve/RetrieveMember.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/retrieve/RetrieveMember.java
@@ -18,7 +18,7 @@ public class RetrieveMember extends AsyncEffect {
     static {
         Skript.registerEffect(
                 RetrieveMember.class,
-                "retrieve [the] member (with|from) id %string% (from|with|of|in) %guild% [(with|using) [the] [bot] %-bot%] and store (it|the member) in %~objects%"
+                "retrieve [the] member (with|from) id %string% (from|with|of|in) %guild% [(with|using) [the] [bot] %-bot%] and store (them|it|the member) in %~objects%"
         );
     }
 


### PR DESCRIPTION
So it's actually in proper English;
```applescript
retrieve the member with id [ ... ] and store them in %object%
```
It's 'them'. It should be 'them'. It never should've been 'it', I'm not an 'it'.
Still, retaining `it` for backward compatibility's sake.