### PR TITLE
Add event-user to member leave event

### DIFF
--- a/src/main/java/net/itsthesky/disky/elements/events/rework/MemberEvents.java
+++ b/src/main/java/net/itsthesky/disky/elements/events/rework/MemberEvents.java
@@ -43,6 +43,7 @@ public class MemberEvents {
                 .example("on member leave:\n    broadcast \"%event-member% has left %event-guild%\"")
                 .value(Guild.class, GuildMemberRemoveEvent::getGuild)
                 .value(Member.class, GuildMemberRemoveEvent::getMember)
+                .value(User.class, GuildMemberRemoveEvent::getUser)
                 .author(GuildMemberRemoveEvent::getGuild)
                 .register();
 


### PR DESCRIPTION
This PR aims to add support for `event-user` to the GuildMemberRemoveEvent
Since `event-member` is reliant on the member being cached this prevented players from easily interacting with its basic data
