### PR TITLE
Implement modal components in DiSky

### DIFF
--- a/src/main/java/net/itsthesky/disky/elements/Types.java
+++ b/src/main/java/net/itsthesky/disky/elements/Types.java
@@ -2,6 +2,7 @@ package net.itsthesky.disky.elements;
 
 import net.dv8tion.jda.api.components.ActionComponent;
 import net.dv8tion.jda.api.components.ModalTopLevelComponent;
+import net.dv8tion.jda.api.components.attachmentupload.AttachmentUpload;
 import net.dv8tion.jda.api.components.buttons.ButtonStyle;
 import net.dv8tion.jda.api.components.selections.SelectOption;
 import net.dv8tion.jda.api.entities.automod.AutoModExecution;
@@ -215,6 +216,9 @@ public class Types {
                 null).eventExpression().register();
         new DiSkyType<>(TextInput.Builder.class, "textinput",
                 TextInput.Builder::getId,
+                null).eventExpression().register();
+        new DiSkyType<>(AttachmentUpload.class, "attachmentupload",
+                AttachmentUpload::getId,
                 null).eventExpression().register();
         DiSkyType.fromEnum(ButtonStyle.class, "buttonstyle", "buttonstyle").register();
 

--- a/src/main/java/net/itsthesky/disky/elements/components/create/ExprNewAttachmentInput.java
+++ b/src/main/java/net/itsthesky/disky/elements/components/create/ExprNewAttachmentInput.java
@@ -1,0 +1,90 @@
+package net.itsthesky.disky.elements.components.create;
+
+/*
+ * DiSky
+ * Copyright (C) 2025 ItsTheSky
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser.ParseResult;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.util.Kleenean;
+import net.dv8tion.jda.api.components.attachmentupload.AttachmentUpload;
+import net.itsthesky.disky.api.skript.EasyElement;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+@Name("New Attachment Upload Input")
+@Description({"Create a new attachment upload component for modals.",
+		"This allows users to upload files through modal interactions.",
+		"The component must be wrapped in a label to be added to a modal.",
+		"Use the 'attachment value' expression to retrieve uploaded files in modal receive events."})
+@Examples({"set {_input} to new attachment upload with id \"user_avatar\"",
+		"set {_label} to new label with label \"Upload your avatar\" with component {_input}",
+		"add {_label} to rows of {_modal}"})
+@Since("4.27.0")
+public class ExprNewAttachmentInput extends SimpleExpression<AttachmentUpload> {
+
+	static {
+		Skript.registerExpression(
+				ExprNewAttachmentInput.class,
+				AttachmentUpload.class,
+				ExpressionType.COMBINED,
+				"[a] [new] attachment[( |-)]upload [with] [the] [id] %string%"
+		);
+	}
+
+	private Expression<String> exprId;
+
+	@Override
+	public boolean init(Expression<?> @NotNull [] exprs, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult) {
+		exprId = (Expression<String>) exprs[0];
+		return true;
+	}
+
+	@Override
+	protected AttachmentUpload @NotNull [] get(@NotNull Event e) {
+		final String id = EasyElement.parseSingle(exprId, e, null);
+		if (EasyElement.anyNull(this, id))
+			return new AttachmentUpload[0];
+
+		final var upload = AttachmentUpload.of(id);
+		return new AttachmentUpload[] {upload};
+	}
+
+	@Override
+	public boolean isSingle() {
+		return true;
+	}
+
+	@Override
+	public @NotNull Class<AttachmentUpload> getReturnType() {
+		return AttachmentUpload.class;
+	}
+
+	@Override
+	public @NotNull String toString(@Nullable Event e, boolean debug) {
+		return "new attachment upload with id " + exprId.toString(e, debug);
+	}
+
+}

--- a/src/main/java/net/itsthesky/disky/elements/components/create/ExprNewLabel.java
+++ b/src/main/java/net/itsthesky/disky/elements/components/create/ExprNewLabel.java
@@ -26,6 +26,7 @@ import ch.njol.skript.lang.SkriptParser;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.util.Kleenean;
 import net.dv8tion.jda.api.components.ModalTopLevelComponent;
+import net.dv8tion.jda.api.components.attachmentupload.AttachmentUpload;
 import net.dv8tion.jda.api.components.label.Label;
 import net.dv8tion.jda.api.components.selections.SelectMenu;
 import net.dv8tion.jda.api.components.textinput.TextInput;
@@ -73,8 +74,10 @@ public class ExprNewLabel extends SimpleExpression<ModalTopLevelComponent> {
             lbl = Label.of(label, desc, textBuilder.build());
         else if (component instanceof final SelectMenu.Builder selectBuilder)
             lbl = Label.of(label, desc, selectBuilder.build());
+        else if (component instanceof final AttachmentUpload attachmentUpload)
+            lbl = Label.of(label, desc, attachmentUpload);
         else {
-            DiSkyRuntimeHandler.error(new IllegalStateException("The component provided cannot fit into a label (only text inputs & select menus are allowed)"), node);
+            DiSkyRuntimeHandler.error(new IllegalStateException("The component provided cannot fit into a label (only text inputs, select menus, and attachment uploads are allowed)"), node);
             return new ModalTopLevelComponent[0];
         }
 


### PR DESCRIPTION
Implements support for file uploads in modal interactions as introduced in JDA 6.1.0. This resolves issue #271 by providing complete Skript syntax for attachment uploads.

Changes:
- Created ExprNewAttachmentInput: New Skript expression to create attachment upload components
- Updated ExprNewLabel: Added support for wrapping AttachmentUpload in labels
- Updated ComponentValue: Added pattern to retrieve uploaded attachments from modal events
- Updated Types: Registered AttachmentUpload as a new type

Skript Syntax:
Creation:
  set {_input} to new attachment upload with id "user_avatar" set {_label} to new label with label "Upload Avatar" with component {_input} add {_label} to rows of {_modal}

Retrieval:
  on modal received: set {_files::*} to attachments of attachment with id "user_avatar"

References:
- Closes #271
- JDA 6.1.0 Release: https://github.com/discord-jda/JDA/releases/tag/v6.1.0