### PR TITLE
📚 Complete documentation with @SeeAlso annotations for all elements

### DIFF
--- a/src/main/java/net/itsthesky/disky/elements/conditions/BotMemberIsInThread.java
+++ b/src/main/java/net/itsthesky/disky/elements/conditions/BotMemberIsInThread.java
@@ -4,6 +4,7 @@ import ch.njol.skript.conditions.base.PropertyCondition;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -21,6 +22,7 @@ import org.jetbrains.annotations.NotNull;
 @Examples({"if event-member is in event-threadchannel:",
         "if bot named \"MyBot\" is not in {_thread}:"})
 @Since("4.0.0")
+@SeeAlso({Member.class, ThreadChannel.class})
 public class BotMemberIsInThread extends EasyPropertyCondition<Object> {
 
     static {

--- a/src/main/java/net/itsthesky/disky/elements/conditions/BotMemberIsInThread.java
+++ b/src/main/java/net/itsthesky/disky/elements/conditions/BotMemberIsInThread.java
@@ -4,7 +4,7 @@ import ch.njol.skript.conditions.base.PropertyCondition;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;

--- a/src/main/java/net/itsthesky/disky/elements/conditions/HasPermissions.java
+++ b/src/main/java/net/itsthesky/disky/elements/conditions/HasPermissions.java
@@ -6,7 +6,7 @@ import ch.njol.skript.conditions.base.PropertyCondition;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Condition;
 import ch.njol.skript.lang.Expression;

--- a/src/main/java/net/itsthesky/disky/elements/conditions/HasPermissions.java
+++ b/src/main/java/net/itsthesky/disky/elements/conditions/HasPermissions.java
@@ -6,6 +6,7 @@ import ch.njol.skript.conditions.base.PropertyCondition;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Condition;
 import ch.njol.skript.lang.Expression;
@@ -27,6 +28,7 @@ import org.skriptlang.skript.registration.SyntaxRegistry;
 @Examples({"if event-member has discord permission administrator: # global permission",
 "if event-member has discord permission send message in event-channel: # channel specific permission"})
 @Since("4.0.0")
+@SeeAlso({Member.class, Permission.class, GuildChannel.class})
 public class HasPermissions extends Condition {
 
     static {

--- a/src/main/java/net/itsthesky/disky/elements/conditions/HasRole.java
+++ b/src/main/java/net/itsthesky/disky/elements/conditions/HasRole.java
@@ -4,6 +4,7 @@ import ch.njol.skript.conditions.base.PropertyCondition;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -19,6 +20,7 @@ import org.jetbrains.annotations.NotNull;
 @Description("Check if a member has a specific role.")
 @Examples({"if event-member has discord role with id \"000\":"})
 @Since("4.0.0")
+@SeeAlso({Member.class, Role.class})
 public class HasRole extends EasyPropertyCondition<Member> {
 
     static {

--- a/src/main/java/net/itsthesky/disky/elements/conditions/HasRole.java
+++ b/src/main/java/net/itsthesky/disky/elements/conditions/HasRole.java
@@ -4,7 +4,7 @@ import ch.njol.skript.conditions.base.PropertyCondition;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;

--- a/src/main/java/net/itsthesky/disky/elements/conditions/IsBot.java
+++ b/src/main/java/net/itsthesky/disky/elements/conditions/IsBot.java
@@ -4,6 +4,7 @@ import ch.njol.skript.conditions.base.PropertyCondition;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import net.dv8tion.jda.api.entities.User;
 
@@ -12,6 +13,7 @@ import net.dv8tion.jda.api.entities.User;
 @Examples({"event-user is a discord bot",
 "event-member is not a discord bot"})
 @Since("4.0.0")
+@SeeAlso(User.class)
 public class IsBot extends PropertyCondition<User> {
 
 	static {

--- a/src/main/java/net/itsthesky/disky/elements/conditions/IsBot.java
+++ b/src/main/java/net/itsthesky/disky/elements/conditions/IsBot.java
@@ -4,7 +4,7 @@ import ch.njol.skript.conditions.base.PropertyCondition;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import net.dv8tion.jda.api.entities.User;
 

--- a/src/main/java/net/itsthesky/disky/elements/conditions/IsDeafen.java
+++ b/src/main/java/net/itsthesky/disky/elements/conditions/IsDeafen.java
@@ -4,6 +4,7 @@ import ch.njol.skript.conditions.base.PropertyCondition;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser;
@@ -18,6 +19,7 @@ import org.jetbrains.annotations.NotNull;
 @Examples({"if event-member is deafened:",
         "if event-member is guild deafened:"})
 @Since("4.14.3")
+@SeeAlso(Member.class)
 public class IsDeafen extends PropertyCondition<Member> {
 
     static {

--- a/src/main/java/net/itsthesky/disky/elements/conditions/IsDeafen.java
+++ b/src/main/java/net/itsthesky/disky/elements/conditions/IsDeafen.java
@@ -4,7 +4,7 @@ import ch.njol.skript.conditions.base.PropertyCondition;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser;

--- a/src/main/java/net/itsthesky/disky/elements/conditions/IsMuted.java
+++ b/src/main/java/net/itsthesky/disky/elements/conditions/IsMuted.java
@@ -4,6 +4,7 @@ import ch.njol.skript.conditions.base.PropertyCondition;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser;
@@ -18,6 +19,7 @@ import org.jetbrains.annotations.NotNull;
 @Examples({"if event-member is muted:",
         "if event-member is self muted:"})
 @Since("4.14.3")
+@SeeAlso(Member.class)
 public class IsMuted extends PropertyCondition<Member> {
 
     static {

--- a/src/main/java/net/itsthesky/disky/elements/conditions/IsMuted.java
+++ b/src/main/java/net/itsthesky/disky/elements/conditions/IsMuted.java
@@ -4,7 +4,7 @@ import ch.njol.skript.conditions.base.PropertyCondition;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser;

--- a/src/main/java/net/itsthesky/disky/elements/conditions/IsTimeout.java
+++ b/src/main/java/net/itsthesky/disky/elements/conditions/IsTimeout.java
@@ -5,6 +5,7 @@ import ch.njol.skript.config.Node;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser;
@@ -19,6 +20,7 @@ import org.jetbrains.annotations.NotNull;
 @Examples({"if event-member is timeout:",
         "\treply with \"This member is currently timed out!\""})
 @Since("4.20.2")
+@SeeAlso(Member.class)
 public class IsTimeout extends PropertyCondition<Member> {
 
     static {

--- a/src/main/java/net/itsthesky/disky/elements/conditions/IsTimeout.java
+++ b/src/main/java/net/itsthesky/disky/elements/conditions/IsTimeout.java
@@ -5,7 +5,7 @@ import ch.njol.skript.config.Node;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser;

--- a/src/main/java/net/itsthesky/disky/elements/conditions/MessageOrigin.java
+++ b/src/main/java/net/itsthesky/disky/elements/conditions/MessageOrigin.java
@@ -4,6 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Condition;
 import ch.njol.skript.lang.Expression;
@@ -21,6 +22,7 @@ import org.jetbrains.annotations.Nullable;
 @Examples({"if event is from guild:",
 "if message come from private message:"})
 @Since("4.0.0")
+@SeeAlso(net.dv8tion.jda.api.entities.Message.class)
 public class MessageOrigin extends Condition {
 
 	static {

--- a/src/main/java/net/itsthesky/disky/elements/conditions/MessageOrigin.java
+++ b/src/main/java/net/itsthesky/disky/elements/conditions/MessageOrigin.java
@@ -4,7 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Condition;
 import ch.njol.skript.lang.Expression;

--- a/src/main/java/net/itsthesky/disky/elements/conditions/isInline.java
+++ b/src/main/java/net/itsthesky/disky/elements/conditions/isInline.java
@@ -4,6 +4,7 @@ import ch.njol.skript.conditions.base.PropertyCondition;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 
@@ -12,6 +13,7 @@ import net.dv8tion.jda.api.entities.MessageEmbed;
 @Examples({"if first element of (fields of last embed) is inline:",
         "if first element of (fields of last embed) is not in-line:"})
 @Since("4.0.0")
+@SeeAlso(MessageEmbed.Field.class)
 public class isInline extends PropertyCondition<MessageEmbed.Field> {
 
     static {

--- a/src/main/java/net/itsthesky/disky/elements/conditions/isInline.java
+++ b/src/main/java/net/itsthesky/disky/elements/conditions/isInline.java
@@ -4,7 +4,7 @@ import ch.njol.skript.conditions.base.PropertyCondition;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 

--- a/src/main/java/net/itsthesky/disky/elements/effects/ArchiveUnarchiveThread.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/ArchiveUnarchiveThread.java
@@ -4,7 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;

--- a/src/main/java/net/itsthesky/disky/elements/effects/ArchiveUnarchiveThread.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/ArchiveUnarchiveThread.java
@@ -4,6 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -22,6 +23,7 @@ import org.jetbrains.annotations.Nullable;
 @Examples({"archive event-threadchannel",
 		"unarchive thread channel with id \"000\""})
 @Since("4.4.0")
+@SeeAlso(ThreadChannel.class)
 public class ArchiveUnarchiveThread extends AsyncEffect {
 
 	static {

--- a/src/main/java/net/itsthesky/disky/elements/effects/AwaitEffect.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/AwaitEffect.java
@@ -2,6 +2,10 @@ package net.itsthesky.disky.elements.effects;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.classes.Changer;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
 import ch.njol.skript.effects.EffChange;
 import ch.njol.skript.lang.Effect;
 import ch.njol.skript.lang.Expression;
@@ -17,6 +21,13 @@ import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+@Name("Await Effect")
+@Description({"Forces an effect to be executed asynchronously and waits for its completion.",
+        "This is useful for non-async effects that need to run in an async context.",
+        "Note: If the effect is already async, using await is redundant."})
+@Examples({"await set {_value} to mention tag \"test\" with id \"000\" # Forces async execution",
+        "await add role with id \"000\" to event-member # Waits for role addition"})
+@Since("4.0.0")
 public class AwaitEffect extends AsyncEffect {
 
     static {

--- a/src/main/java/net/itsthesky/disky/elements/effects/BanMember.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/BanMember.java
@@ -5,6 +5,7 @@ import ch.njol.skript.config.Node;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -27,6 +28,7 @@ import java.util.concurrent.TimeUnit;
 @Examples({"ban discord event-member because of \"being lame\" and delete 10 days worth of messages",
 	"ban discord member \"00000000000\" from guild with id \"000\" due to \"being lame\""})
 @Since("4.0.0")
+@SeeAlso({Guild.class, Member.class})
 
 public class BanMember extends AsyncEffect {
 

--- a/src/main/java/net/itsthesky/disky/elements/effects/BanMember.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/BanMember.java
@@ -5,7 +5,7 @@ import ch.njol.skript.config.Node;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;

--- a/src/main/java/net/itsthesky/disky/elements/effects/ConnectBot.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/ConnectBot.java
@@ -4,7 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;

--- a/src/main/java/net/itsthesky/disky/elements/effects/ConnectBot.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/ConnectBot.java
@@ -4,6 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -28,6 +29,7 @@ import static net.itsthesky.disky.api.skript.EasyElement.parseSingle;
 })
 @Examples({"connect bot \"bot_name\" to voice channel with id \"000\"",
 		"disconnect from event-guild"})
+@SeeAlso({AudioChannel.class, Guild.class})
 @Since("4.9.0")
 public class ConnectBot extends AsyncEffect {
 

--- a/src/main/java/net/itsthesky/disky/elements/effects/CreateAction.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/CreateAction.java
@@ -6,7 +6,7 @@ import ch.njol.skript.config.Node;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;

--- a/src/main/java/net/itsthesky/disky/elements/effects/CreateAction.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/CreateAction.java
@@ -6,6 +6,7 @@ import ch.njol.skript.config.Node;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -26,6 +27,7 @@ import static net.itsthesky.disky.api.skript.EasyElement.parseSingle;
 @Examples({"create {_action} and store it in {_channel}",
         "create {_roleaction} and store the role in {_role}"})
 @Since("4.0.0")
+@SeeAlso(AuditableRestAction.class)
 @SuppressWarnings("unchecked")
 public class CreateAction extends AsyncEffect implements INodeHolder {
 

--- a/src/main/java/net/itsthesky/disky/elements/effects/CreateEmote.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/CreateEmote.java
@@ -5,7 +5,7 @@ import ch.njol.skript.classes.Changer;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;

--- a/src/main/java/net/itsthesky/disky/elements/effects/CreateEmote.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/CreateEmote.java
@@ -5,6 +5,7 @@ import ch.njol.skript.classes.Changer;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -31,6 +32,7 @@ import static net.itsthesky.disky.api.skript.EasyElement.anyNull;
 @Examples({"create new emote named \"test\" with url \"https://static.wikia.nocookie.net/leagueoflegends/images/a/ae/This_Changes_Everything_Emote.png/revision/latest/scale-to-width-down/250?cb=20211019231749\" in event-guild and store it in {_emote}",
 "make emote with name \"test2\" with path \"plugins/path/image.png\" in event-guild and store it in {_emote}"})
 @Since("4.0.0")
+@SeeAlso({Guild.class, Icon.class})
 public class CreateEmote extends AsyncEffect {
 
     static {

--- a/src/main/java/net/itsthesky/disky/elements/effects/CreateInvite.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/CreateInvite.java
@@ -6,7 +6,7 @@ import ch.njol.skript.config.Node;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;

--- a/src/main/java/net/itsthesky/disky/elements/effects/CreateInvite.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/CreateInvite.java
@@ -6,6 +6,7 @@ import ch.njol.skript.config.Node;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -32,6 +33,7 @@ import static net.itsthesky.disky.api.skript.EasyElement.parseSingle;
 @Examples({"create invite in event-guild and store it in {_invite}",
         "create invite in event-channel with max uses 10 and store it in {_inv}"})
 @Since("4.0.0")
+@SeeAlso({Guild.class, Invite.class})
 public class CreateInvite extends AsyncEffect {
 
     static {

--- a/src/main/java/net/itsthesky/disky/elements/effects/CreatePost.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/CreatePost.java
@@ -5,7 +5,7 @@ import ch.njol.skript.classes.Changer;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;

--- a/src/main/java/net/itsthesky/disky/elements/effects/CreatePost.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/CreatePost.java
@@ -5,6 +5,7 @@ import ch.njol.skript.classes.Changer;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;

--- a/src/main/java/net/itsthesky/disky/elements/effects/CreateScheduledEvent.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/CreateScheduledEvent.java
@@ -5,7 +5,7 @@ import ch.njol.skript.classes.Changer;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;

--- a/src/main/java/net/itsthesky/disky/elements/effects/CreateScheduledEvent.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/CreateScheduledEvent.java
@@ -5,6 +5,7 @@ import ch.njol.skript.classes.Changer;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -34,6 +35,7 @@ import static net.itsthesky.disky.api.skript.EasyElement.parseSingle;
 		"create scheduled event named \"Concerto\" at \"6 routes of XXX\" starting (1 hour after now) and ending (5 hours after now) in event-guild and store it in {_event}"
 })
 @Since("4.0.0")
+@SeeAlso({Guild.class, ScheduledEvent.class})
 public class CreateScheduledEvent extends AsyncEffect {
 
 	static {

--- a/src/main/java/net/itsthesky/disky/elements/effects/CreateThread.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/CreateThread.java
@@ -5,6 +5,7 @@ import ch.njol.skript.classes.Changer;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -33,6 +34,7 @@ import static net.itsthesky.disky.api.skript.EasyElement.parseSingle;
 @Examples({"create thread named \"Discussion\" in event-channel and store it in {_thread}",
         "create private thread named \"Staff Room\" in channel with id \"000\""})
 @Since("4.0.0")
+@SeeAlso({Message.class, ThreadChannel.class})
 public class CreateThread extends AsyncEffect {
 
     static {

--- a/src/main/java/net/itsthesky/disky/elements/effects/CreateThread.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/CreateThread.java
@@ -5,7 +5,7 @@ import ch.njol.skript.classes.Changer;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;

--- a/src/main/java/net/itsthesky/disky/elements/effects/DeferInteraction.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/DeferInteraction.java
@@ -4,7 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;

--- a/src/main/java/net/itsthesky/disky/elements/effects/DeferInteraction.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/DeferInteraction.java
@@ -4,6 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -35,6 +36,7 @@ import java.util.Set;
 "defer the interaction and wait",
 "defer the interaction and wait silently"})
 @Since("4.0.0")
+@SeeAlso(IReplyCallback.class)
 public class DeferInteraction extends AsyncEffect {
 
     public static final Set<Long> WAITING_INTERACTIONS = new HashSet<>();

--- a/src/main/java/net/itsthesky/disky/elements/effects/DestroyEntity.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/DestroyEntity.java
@@ -5,6 +5,7 @@ import ch.njol.skript.config.Node;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -33,6 +34,7 @@ import static net.itsthesky.disky.api.skript.EasyElement.parseSingle;
 @Examples({"destroy event-channel",
 "destroy event-message"})
 @Since("4.0.0")
+@SeeAlso({Guild.class, Message.class, Role.class})
 public class DestroyEntity extends AsyncEffect {
 
 	static {

--- a/src/main/java/net/itsthesky/disky/elements/effects/DestroyEntity.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/DestroyEntity.java
@@ -5,7 +5,7 @@ import ch.njol.skript.config.Node;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;

--- a/src/main/java/net/itsthesky/disky/elements/effects/EditMessage.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/EditMessage.java
@@ -5,6 +5,7 @@ import ch.njol.skript.config.Node;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -38,6 +39,7 @@ import static net.itsthesky.disky.api.skript.EasyElement.parseSingle;
 				"edit {_msg} to show \"Abracadabra!\""
 )
 @Since("4.4.0")
+@SeeAlso(Message.class)
 public class EditMessage extends AsyncEffect {
 
 	static {

--- a/src/main/java/net/itsthesky/disky/elements/effects/EditMessage.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/EditMessage.java
@@ -5,7 +5,7 @@ import ch.njol.skript.config.Node;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;

--- a/src/main/java/net/itsthesky/disky/elements/effects/EndPoll.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/EndPoll.java
@@ -5,6 +5,7 @@ import ch.njol.skript.config.Node;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser;
@@ -23,6 +24,7 @@ import org.jetbrains.annotations.Nullable;
 @Examples({"end poll of event-message",
         "end the poll of {_msg} now"})
 @Since("4.17.0")
+@SeeAlso(Message.class)
 public class EndPoll extends AsyncEffect {
 
     static {

--- a/src/main/java/net/itsthesky/disky/elements/effects/EndPoll.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/EndPoll.java
@@ -5,7 +5,7 @@ import ch.njol.skript.config.Node;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser;

--- a/src/main/java/net/itsthesky/disky/elements/effects/ForwardMessage.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/ForwardMessage.java
@@ -6,6 +6,7 @@ import ch.njol.skript.config.Node;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser;
@@ -24,6 +25,7 @@ import org.jetbrains.annotations.Nullable;
 @Examples({"forward event-message to channel with id \"000\"",
         "forward {_msg} to {_channel} and store it in {_forwarded}"})
 @Since("4.20.0")
+@SeeAlso({Message.class, MessageChannel.class})
 public class ForwardMessage extends AsyncEffect implements INodeHolder {
 
     static {

--- a/src/main/java/net/itsthesky/disky/elements/effects/ForwardMessage.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/ForwardMessage.java
@@ -6,7 +6,7 @@ import ch.njol.skript.config.Node;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser;

--- a/src/main/java/net/itsthesky/disky/elements/effects/KickMember.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/KickMember.java
@@ -4,7 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;

--- a/src/main/java/net/itsthesky/disky/elements/effects/KickMember.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/KickMember.java
@@ -4,6 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -22,6 +23,7 @@ import static net.itsthesky.disky.api.skript.EasyElement.parseSingle;
 @Description("Kick a specific member out of its guild. You can also specify a reason if needed.")
 @Examples("kick discord event-member due to \"ur bad guys!\"")
 @Since("4.0.0")
+@SeeAlso(Member.class)
 public class KickMember extends AsyncEffect {
 
     static {

--- a/src/main/java/net/itsthesky/disky/elements/effects/LoadMembers.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/LoadMembers.java
@@ -5,6 +5,7 @@ import ch.njol.skript.classes.Changer;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -28,6 +29,7 @@ import static net.itsthesky.disky.api.skript.EasyElement.parseSingle;
 "consider calling this effect once, then use the default member expression to get the members."})
 @Examples("load members of event-guild and store them in {_members::*}")
 @Since("4.0.0")
+@SeeAlso({Guild.class, Member.class})
 public class LoadMembers extends AsyncEffect {
 
 	static {

--- a/src/main/java/net/itsthesky/disky/elements/effects/LoadMembers.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/LoadMembers.java
@@ -5,7 +5,7 @@ import ch.njol.skript.classes.Changer;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;

--- a/src/main/java/net/itsthesky/disky/elements/effects/LockUnlockThread.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/LockUnlockThread.java
@@ -4,7 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;

--- a/src/main/java/net/itsthesky/disky/elements/effects/LockUnlockThread.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/LockUnlockThread.java
@@ -4,6 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -24,6 +25,7 @@ import static net.itsthesky.disky.api.skript.EasyElement.parseSingle;
 @Examples({"lock event-threadchannel",
 		"unlock thread channel with id \"000\""})
 @Since("4.4.0")
+@SeeAlso(ThreadChannel.class)
 public class LockUnlockThread extends AsyncEffect {
 
 	static {

--- a/src/main/java/net/itsthesky/disky/elements/effects/MakeBotLeave.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/MakeBotLeave.java
@@ -4,7 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;

--- a/src/main/java/net/itsthesky/disky/elements/effects/MakeBotLeave.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/MakeBotLeave.java
@@ -4,6 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -20,6 +21,7 @@ import org.jetbrains.annotations.Nullable;
 @Description("Make a bot leave a specific guild. The bot will no longer have access to that server.")
 @Examples("make bot \"MyBot\" leave event-guild")
 @Since("4.0.0")
+@SeeAlso(Guild.class)
 public class MakeBotLeave extends AsyncEffect {
 
     static {

--- a/src/main/java/net/itsthesky/disky/elements/effects/MoveMember.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/MoveMember.java
@@ -4,7 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;

--- a/src/main/java/net/itsthesky/disky/elements/effects/MoveMember.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/MoveMember.java
@@ -4,6 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -26,6 +27,7 @@ import static net.itsthesky.disky.api.skript.EasyElement.parseSingle;
 @Examples({"move discord event-member to {_voice}",
         "disconnect discord event-member"})
 @Since("4.14.2")
+@SeeAlso({Member.class, VoiceChannel.class})
 public class MoveMember extends AsyncEffect {
 
     static {

--- a/src/main/java/net/itsthesky/disky/elements/effects/MoveRole.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/MoveRole.java
@@ -5,6 +5,7 @@ import ch.njol.skript.config.Node;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -25,6 +26,7 @@ import static net.itsthesky.disky.api.skript.EasyElement.parseSingle;
 "The indexes will be updated automatically."})
 @Examples("move role {_role} above role with id \"000\"")
 @Since("4.0.0")
+@SeeAlso(Role.class)
 public class MoveRole extends AsyncEffect {
 
 	static {

--- a/src/main/java/net/itsthesky/disky/elements/effects/MoveRole.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/MoveRole.java
@@ -5,7 +5,7 @@ import ch.njol.skript.config.Node;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;

--- a/src/main/java/net/itsthesky/disky/elements/effects/MuteMember.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/MuteMember.java
@@ -4,7 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;

--- a/src/main/java/net/itsthesky/disky/elements/effects/MuteMember.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/MuteMember.java
@@ -4,6 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -23,6 +24,7 @@ import static net.itsthesky.disky.api.skript.EasyElement.parseSingle;
 @Examples({"voice mute event-member",
         "unmute member event-member"})
 @Since("4.0.0")
+@SeeAlso(Member.class)
 public class MuteMember extends AsyncEffect {
 
     static {

--- a/src/main/java/net/itsthesky/disky/elements/effects/OpenPrivateChannel.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/OpenPrivateChannel.java
@@ -6,7 +6,7 @@ import ch.njol.skript.config.Node;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;

--- a/src/main/java/net/itsthesky/disky/elements/effects/OpenPrivateChannel.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/OpenPrivateChannel.java
@@ -6,6 +6,7 @@ import ch.njol.skript.config.Node;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -28,6 +29,7 @@ import static net.itsthesky.disky.api.skript.EasyElement.parseSingle;
         "if {_channel} is not set:",
         "\treply with \"Please enable your private messages!\""})
 @Since("4.0.0")
+@SeeAlso({User.class, PrivateChannel.class})
 public class OpenPrivateChannel extends AsyncEffect {
 
     static {

--- a/src/main/java/net/itsthesky/disky/elements/effects/PinMessage.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/PinMessage.java
@@ -5,6 +5,7 @@ import ch.njol.skript.config.Node;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -24,6 +25,7 @@ import org.jetbrains.annotations.Nullable;
 @Examples({"pin event-message",
         "unpin last message in event-channel"})
 @Since("4.0.0")
+@SeeAlso(Message.class)
 public class PinMessage extends AsyncEffect {
 
     static {

--- a/src/main/java/net/itsthesky/disky/elements/effects/PinMessage.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/PinMessage.java
@@ -5,7 +5,7 @@ import ch.njol.skript.config.Node;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;

--- a/src/main/java/net/itsthesky/disky/elements/effects/PostMessage.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/PostMessage.java
@@ -6,7 +6,7 @@ import ch.njol.skript.config.Node;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;

--- a/src/main/java/net/itsthesky/disky/elements/effects/PostMessage.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/PostMessage.java
@@ -6,6 +6,7 @@ import ch.njol.skript.config.Node;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -46,6 +47,7 @@ import static net.itsthesky.disky.api.skript.EasyElement.parseSingle;
 @Examples({"post \"Hello world!\" to text channel with id \"000\"",
 		"post last embed to thread channel with id \"000\" and store it in {_message}"})
 @Since("4.4.0")
+@SeeAlso({Message.class, Channel.class, GuildMessageChannel.class})
 public class PostMessage extends AsyncEffect {
 
 	private static final long MAX_FILE_SIZE = 25 * 1024 * 1024; // 25MB en bytes

--- a/src/main/java/net/itsthesky/disky/elements/effects/PublishMessage.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/PublishMessage.java
@@ -4,7 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;

--- a/src/main/java/net/itsthesky/disky/elements/effects/PublishMessage.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/PublishMessage.java
@@ -4,6 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -22,6 +23,7 @@ import org.jetbrains.annotations.Nullable;
 @Examples({"publish event-message",
         "crosspost message with id \"000\" in channel with id \"123\""})
 @Since("4.0.0")
+@SeeAlso(Message.class)
 public class PublishMessage extends SpecificBotEffect {
 
     static {

--- a/src/main/java/net/itsthesky/disky/elements/effects/PurgeMessages.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/PurgeMessages.java
@@ -4,7 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;

--- a/src/main/java/net/itsthesky/disky/elements/effects/PurgeMessages.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/PurgeMessages.java
@@ -4,6 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -27,6 +28,7 @@ import java.util.List;
 @Examples({"retrieve last 50 messages from event-channel and store them in {_msg::*}",
 "purge {_msg::*}"})
 @Since("4.0.0")
+@SeeAlso({Message.class, MessageChannel.class})
 public class PurgeMessages extends SpecificBotEffect {
 
     static {

--- a/src/main/java/net/itsthesky/disky/elements/effects/ReplyWith.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/ReplyWith.java
@@ -7,6 +7,7 @@ import ch.njol.skript.config.SectionNode;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -58,6 +59,7 @@ import static net.itsthesky.disky.api.skript.EasyElement.*;
 				"wait a second",
 		"edit {_msg} to show \"... world!\""})
 @Since("4.4.0")
+@SeeAlso({Message.class, GuildMessageChannel.class, Sticker.class})
 public class ReplyWith extends AsyncEffectSection {
 
 	static {

--- a/src/main/java/net/itsthesky/disky/elements/effects/ReplyWith.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/ReplyWith.java
@@ -7,7 +7,7 @@ import ch.njol.skript.config.SectionNode;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;

--- a/src/main/java/net/itsthesky/disky/elements/effects/RetrieveEventValue.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/RetrieveEventValue.java
@@ -1,6 +1,10 @@
 package net.itsthesky.disky.elements.effects;
 
 import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.parser.ParserInstance;
@@ -20,6 +24,15 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+@Name("Retrieve Event Value")
+@Description({"Retrieves specific event values asynchronously in certain DiSky events.",
+        "These values need to be fetched from Discord's API and cannot be provided directly in the event.",
+        "The value must be stored in a variable for later use.",
+        "Each event has its own set of retrievable values - check the event documentation for available values."})
+@Examples({"on guild member join:",
+        "\tretrieve event-value \"user\" and store it in {_user}",
+        "\tsend \"Welcome %{_user}%!\" to event-channel"})
+@Since("4.0.0")
 @SuppressWarnings("ALL")
 public class RetrieveEventValue extends WaiterEffect<Object> {
 

--- a/src/main/java/net/itsthesky/disky/elements/effects/SendTyping.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/SendTyping.java
@@ -5,7 +5,7 @@ import ch.njol.skript.config.Node;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;

--- a/src/main/java/net/itsthesky/disky/elements/effects/SendTyping.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/SendTyping.java
@@ -5,6 +5,7 @@ import ch.njol.skript.config.Node;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -26,6 +27,7 @@ import org.jetbrains.annotations.Nullable;
         "Typing status lasts for 10 seconds."})
 @Examples({"show typing status in event-channel"})
 @Since("4.0.0")
+@SeeAlso({Channel.class, MessageChannel.class})
 public class SendTyping extends AsyncEffect {
 
     static {

--- a/src/main/java/net/itsthesky/disky/elements/effects/SuppressEmbed.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/SuppressEmbed.java
@@ -4,6 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser;
@@ -20,6 +21,7 @@ import org.jetbrains.annotations.Nullable;
 @Description("Suppress/hide link embeds from a specific message.")
 @Examples("suppress embeds from event-message")
 @Since("4.0.0")
+@SeeAlso(Message.class)
 public class SuppressEmbed extends SpecificBotEffect {
 
     static {

--- a/src/main/java/net/itsthesky/disky/elements/effects/SuppressEmbed.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/SuppressEmbed.java
@@ -4,7 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser;

--- a/src/main/java/net/itsthesky/disky/elements/effects/SuppressReaction.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/SuppressReaction.java
@@ -4,7 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;

--- a/src/main/java/net/itsthesky/disky/elements/effects/SuppressReaction.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/SuppressReaction.java
@@ -4,6 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -30,6 +31,7 @@ import java.util.List;
 @Examples({"suppress reaction \"x\" of event-user from event-message",
 		"suppress reaction \"joy\" from event-message # Remove the reaction ADDED BY THE BOT"})
 @Since("4.1.1")
+@SeeAlso({Message.class, User.class})
 public class SuppressReaction extends SpecificBotEffect {
 
 	static {

--- a/src/main/java/net/itsthesky/disky/elements/effects/TimeOutMember.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/TimeOutMember.java
@@ -4,7 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;

--- a/src/main/java/net/itsthesky/disky/elements/effects/TimeOutMember.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/TimeOutMember.java
@@ -4,6 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -31,6 +32,7 @@ import java.time.Instant;
 "time out event-member until {_date}",
 "stop time out of event-member"})
 @Since("4.0.0")
+@SeeAlso(Member.class)
 public class TimeOutMember extends SpecificBotEffect {
 
 	static {

--- a/src/main/java/net/itsthesky/disky/elements/effects/UnbanMember.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/UnbanMember.java
@@ -5,6 +5,7 @@ import ch.njol.skript.config.Node;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -23,6 +24,7 @@ import org.jetbrains.annotations.Nullable;
 @Description("Unbans a user from a guild.")
 @Examples("unban event-user in guild with id \"818182471140114432\"")
 @Since("4.0.0")
+@SeeAlso({Guild.class, User.class})
 public class UnbanMember extends AsyncEffect {
 
     static {

--- a/src/main/java/net/itsthesky/disky/elements/effects/UnbanMember.java
+++ b/src/main/java/net/itsthesky/disky/elements/effects/UnbanMember.java
@@ -5,7 +5,7 @@ import ch.njol.skript.config.Node;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;

--- a/src/main/java/net/itsthesky/disky/elements/getters/BaseGetterExpression.java
+++ b/src/main/java/net/itsthesky/disky/elements/getters/BaseGetterExpression.java
@@ -2,6 +2,10 @@ package net.itsthesky.disky.elements.getters;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.config.Node;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -15,6 +19,13 @@ import org.bukkit.event.Event;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+@Name("Base Getter Expression")
+@Description({"Abstract base class for DiSky getter expressions.",
+        "Provides common functionality for expressions that retrieve Discord entities by ID.",
+        "This is an internal utility class extended by specific getter implementations.",
+        "Not directly usable in Skript code."})
+@Examples("# This is a base class - see specific getter expressions like 'guild with id', 'user with id', etc.")
+@Since("4.0.0")
 @SuppressWarnings({"unchecked"})
 public abstract class BaseGetterExpression<T> extends SimpleExpression<T> implements IAsyncGettableExpression<T> {
 

--- a/src/main/java/net/itsthesky/disky/elements/getters/ExprEmoji.java
+++ b/src/main/java/net/itsthesky/disky/elements/getters/ExprEmoji.java
@@ -5,7 +5,7 @@ import ch.njol.skript.config.Node;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;

--- a/src/main/java/net/itsthesky/disky/elements/getters/ExprEmoji.java
+++ b/src/main/java/net/itsthesky/disky/elements/getters/ExprEmoji.java
@@ -5,6 +5,7 @@ import ch.njol.skript.config.Node;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
@@ -42,6 +43,7 @@ import java.util.regex.Pattern;
         "emote \"disky\" in event-guild",
 })
 @Since("4.0.0")
+@SeeAlso({Guild.class, RichCustomEmoji.class})
 public class ExprEmoji extends SimpleExpression<Emote> implements IAsyncGettableExpression<Emote> {
     static {
         Skript.registerExpression(ExprEmoji.class, Emote.class, ExpressionType.SIMPLE,

--- a/src/main/java/net/itsthesky/disky/elements/getters/GetAudioChannel.java
+++ b/src/main/java/net/itsthesky/disky/elements/getters/GetAudioChannel.java
@@ -3,7 +3,7 @@ package net.itsthesky.disky.elements.getters;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import net.itsthesky.disky.core.Bot;
 import net.dv8tion.jda.api.entities.channel.middleman.AudioChannel;

--- a/src/main/java/net/itsthesky/disky/elements/getters/GetAudioChannel.java
+++ b/src/main/java/net/itsthesky/disky/elements/getters/GetAudioChannel.java
@@ -3,6 +3,7 @@ package net.itsthesky.disky.elements.getters;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import net.itsthesky.disky.core.Bot;
 import net.dv8tion.jda.api.entities.channel.middleman.AudioChannel;
@@ -15,6 +16,7 @@ import org.jetbrains.annotations.NotNull;
 		"This expression cannot be changed."})
 @Examples("audio channel with id \"000\"")
 @Since("4.0.0")
+@SeeAlso(AudioChannel.class)
 public class GetAudioChannel extends BaseGetterExpression<AudioChannel> {
 
 	static {

--- a/src/main/java/net/itsthesky/disky/elements/getters/GetAutoModRule.java
+++ b/src/main/java/net/itsthesky/disky/elements/getters/GetAutoModRule.java
@@ -5,7 +5,7 @@ import ch.njol.skript.config.Node;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;

--- a/src/main/java/net/itsthesky/disky/elements/getters/GetAutoModRule.java
+++ b/src/main/java/net/itsthesky/disky/elements/getters/GetAutoModRule.java
@@ -5,6 +5,7 @@ import ch.njol.skript.config.Node;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
@@ -23,6 +24,7 @@ import org.jetbrains.annotations.Nullable;
 @Description("Get an automod rule from a guild using its unique ID.")
 @Examples("automod rule with id \"000\" in event-guild")
 @Since("4.17.0")
+@SeeAlso({Guild.class, AutoModRule.class})
 public class GetAutoModRule extends SimpleExpression<AutoModRule>
         implements IAsyncGettableExpression<AutoModRule> {
 

--- a/src/main/java/net/itsthesky/disky/elements/getters/GetCategory.java
+++ b/src/main/java/net/itsthesky/disky/elements/getters/GetCategory.java
@@ -3,7 +3,7 @@ package net.itsthesky.disky.elements.getters;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import net.itsthesky.disky.core.Bot;
 import net.dv8tion.jda.api.entities.channel.concrete.Category;

--- a/src/main/java/net/itsthesky/disky/elements/getters/GetCategory.java
+++ b/src/main/java/net/itsthesky/disky/elements/getters/GetCategory.java
@@ -3,6 +3,7 @@ package net.itsthesky.disky.elements.getters;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import net.itsthesky.disky.core.Bot;
 import net.dv8tion.jda.api.entities.channel.concrete.Category;
@@ -14,6 +15,7 @@ import org.jetbrains.annotations.NotNull;
         "This expression cannot be changed."})
 @Examples("category with id \"000\"")
 @Since("4.0.0")
+@SeeAlso(Category.class)
 public class GetCategory extends BaseGetterExpression<Category> {
 
     static {

--- a/src/main/java/net/itsthesky/disky/elements/getters/GetChannel.java
+++ b/src/main/java/net/itsthesky/disky/elements/getters/GetChannel.java
@@ -3,7 +3,7 @@ package net.itsthesky.disky.elements.getters;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import net.itsthesky.disky.core.Bot;
 import net.dv8tion.jda.api.entities.channel.Channel;

--- a/src/main/java/net/itsthesky/disky/elements/getters/GetChannel.java
+++ b/src/main/java/net/itsthesky/disky/elements/getters/GetChannel.java
@@ -3,6 +3,7 @@ package net.itsthesky.disky.elements.getters;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import net.itsthesky.disky.core.Bot;
 import net.dv8tion.jda.api.entities.channel.Channel;
@@ -12,6 +13,7 @@ import net.dv8tion.jda.api.entities.channel.Channel;
 "This can return a text, private, news, voice, category, stage, thread or post channel."})
 @Examples("post last embed to channel with id \"000\"")
 @Since("4.4.2")
+@SeeAlso(Channel.class)
 public class GetChannel extends BaseGetterExpression<Channel> {
 
 	static {

--- a/src/main/java/net/itsthesky/disky/elements/getters/GetForumChannel.java
+++ b/src/main/java/net/itsthesky/disky/elements/getters/GetForumChannel.java
@@ -3,6 +3,7 @@ package net.itsthesky.disky.elements.getters;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import net.itsthesky.disky.core.Bot;
 import net.dv8tion.jda.api.entities.channel.concrete.ForumChannel;
@@ -14,6 +15,7 @@ import org.jetbrains.annotations.NotNull;
         "This expression cannot be changed."})
 @Examples("forum channel with id \"000\"")
 @Since("4.4.4")
+@SeeAlso(ForumChannel.class)
 public class GetForumChannel extends BaseGetterExpression<ForumChannel> {
 
     static {

--- a/src/main/java/net/itsthesky/disky/elements/getters/GetForumChannel.java
+++ b/src/main/java/net/itsthesky/disky/elements/getters/GetForumChannel.java
@@ -3,7 +3,7 @@ package net.itsthesky.disky.elements.getters;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import net.itsthesky.disky.core.Bot;
 import net.dv8tion.jda.api.entities.channel.concrete.ForumChannel;

--- a/src/main/java/net/itsthesky/disky/elements/getters/GetGuild.java
+++ b/src/main/java/net/itsthesky/disky/elements/getters/GetGuild.java
@@ -3,7 +3,7 @@ package net.itsthesky.disky.elements.getters;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import net.itsthesky.disky.core.Bot;
 import net.dv8tion.jda.api.entities.Guild;

--- a/src/main/java/net/itsthesky/disky/elements/getters/GetGuild.java
+++ b/src/main/java/net/itsthesky/disky/elements/getters/GetGuild.java
@@ -3,6 +3,7 @@ package net.itsthesky.disky.elements.getters;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import net.itsthesky.disky.core.Bot;
 import net.dv8tion.jda.api.entities.Guild;
@@ -13,6 +14,7 @@ import org.jetbrains.annotations.NotNull;
         "This expression cannot be changed."})
 @Examples("guild with id \"000\"")
 @Since("4.0.0")
+@SeeAlso(Guild.class)
 public class GetGuild extends BaseGetterExpression<Guild> {
 
     static {

--- a/src/main/java/net/itsthesky/disky/elements/getters/GetGuildChannel.java
+++ b/src/main/java/net/itsthesky/disky/elements/getters/GetGuildChannel.java
@@ -3,7 +3,7 @@ package net.itsthesky.disky.elements.getters;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import net.itsthesky.disky.core.Bot;
 import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel;

--- a/src/main/java/net/itsthesky/disky/elements/getters/GetGuildChannel.java
+++ b/src/main/java/net/itsthesky/disky/elements/getters/GetGuildChannel.java
@@ -3,6 +3,7 @@ package net.itsthesky.disky.elements.getters;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import net.itsthesky.disky.core.Bot;
 import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel;
@@ -14,6 +15,7 @@ import org.jetbrains.annotations.NotNull;
         "This expression cannot be changed."})
 @Examples("guild channel with id \"000\"")
 @Since("4.0.0")
+@SeeAlso(GuildChannel.class)
 public class GetGuildChannel extends BaseGetterExpression<GuildChannel> {
 
     static {

--- a/src/main/java/net/itsthesky/disky/elements/getters/GetMember.java
+++ b/src/main/java/net/itsthesky/disky/elements/getters/GetMember.java
@@ -4,7 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;

--- a/src/main/java/net/itsthesky/disky/elements/getters/GetMember.java
+++ b/src/main/java/net/itsthesky/disky/elements/getters/GetMember.java
@@ -4,6 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
@@ -27,6 +28,7 @@ import org.jetbrains.annotations.Nullable;
         "This expression cannot be changed"})
 @Examples({"member with id \"000\" in event-guild"})
 @Since("4.0.0")
+@SeeAlso({Guild.class, Member.class})
 public class GetMember extends SimpleExpression<Member> implements IAsyncGettableExpression<Member> {
 
     static {

--- a/src/main/java/net/itsthesky/disky/elements/getters/GetMessageChannel.java
+++ b/src/main/java/net/itsthesky/disky/elements/getters/GetMessageChannel.java
@@ -3,7 +3,7 @@ package net.itsthesky.disky.elements.getters;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import net.itsthesky.disky.core.Bot;
 import net.dv8tion.jda.api.entities.channel.middleman.GuildMessageChannel;

--- a/src/main/java/net/itsthesky/disky/elements/getters/GetMessageChannel.java
+++ b/src/main/java/net/itsthesky/disky/elements/getters/GetMessageChannel.java
@@ -3,6 +3,7 @@ package net.itsthesky.disky.elements.getters;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import net.itsthesky.disky.core.Bot;
 import net.dv8tion.jda.api.entities.channel.middleman.GuildMessageChannel;
@@ -14,6 +15,7 @@ import org.jetbrains.annotations.NotNull;
 		"This expression cannot be changed."})
 @Examples("message channel with id \"000\"")
 @Since("4.0.0")
+@SeeAlso(GuildMessageChannel.class)
 public class GetMessageChannel extends BaseGetterExpression<GuildMessageChannel> {
 
 	static {

--- a/src/main/java/net/itsthesky/disky/elements/getters/GetNewsChannel.java
+++ b/src/main/java/net/itsthesky/disky/elements/getters/GetNewsChannel.java
@@ -3,6 +3,7 @@ package net.itsthesky.disky.elements.getters;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import net.itsthesky.disky.core.Bot;
 import net.dv8tion.jda.api.entities.channel.concrete.NewsChannel;
@@ -14,6 +15,7 @@ import org.jetbrains.annotations.NotNull;
         "This expression cannot be changed."})
 @Examples("news channel with id \"000\"")
 @Since("4.0.0")
+@SeeAlso(NewsChannel.class)
 public class GetNewsChannel extends BaseGetterExpression<NewsChannel> {
 
     static {

--- a/src/main/java/net/itsthesky/disky/elements/getters/GetNewsChannel.java
+++ b/src/main/java/net/itsthesky/disky/elements/getters/GetNewsChannel.java
@@ -3,7 +3,7 @@ package net.itsthesky.disky.elements.getters;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import net.itsthesky.disky.core.Bot;
 import net.dv8tion.jda.api.entities.channel.concrete.NewsChannel;

--- a/src/main/java/net/itsthesky/disky/elements/getters/GetRole.java
+++ b/src/main/java/net/itsthesky/disky/elements/getters/GetRole.java
@@ -3,7 +3,7 @@ package net.itsthesky.disky.elements.getters;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import net.itsthesky.disky.core.Bot;
 import net.dv8tion.jda.api.entities.Role;

--- a/src/main/java/net/itsthesky/disky/elements/getters/GetRole.java
+++ b/src/main/java/net/itsthesky/disky/elements/getters/GetRole.java
@@ -3,6 +3,7 @@ package net.itsthesky.disky.elements.getters;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import net.itsthesky.disky.core.Bot;
 import net.dv8tion.jda.api.entities.Role;
@@ -14,6 +15,7 @@ import org.jetbrains.annotations.NotNull;
         "This expression cannot be changed."})
 @Examples("role with id \"000\"")
 @Since("4.0.0")
+@SeeAlso(Role.class)
 public class GetRole extends BaseGetterExpression<Role> {
 
     static {

--- a/src/main/java/net/itsthesky/disky/elements/getters/GetScheduledEvent.java
+++ b/src/main/java/net/itsthesky/disky/elements/getters/GetScheduledEvent.java
@@ -3,7 +3,7 @@ package net.itsthesky.disky.elements.getters;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import net.itsthesky.disky.core.Bot;
 import net.dv8tion.jda.api.entities.ScheduledEvent;

--- a/src/main/java/net/itsthesky/disky/elements/getters/GetScheduledEvent.java
+++ b/src/main/java/net/itsthesky/disky/elements/getters/GetScheduledEvent.java
@@ -3,6 +3,7 @@ package net.itsthesky.disky.elements.getters;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import net.itsthesky.disky.core.Bot;
 import net.dv8tion.jda.api.entities.ScheduledEvent;
@@ -14,6 +15,7 @@ import org.jetbrains.annotations.NotNull;
         "This expression cannot be changed."})
 @Examples("scheduled event with id \"000\"")
 @Since("4.0.0")
+@SeeAlso(ScheduledEvent.class)
 public class GetScheduledEvent extends BaseGetterExpression<ScheduledEvent> {
 
     static {

--- a/src/main/java/net/itsthesky/disky/elements/getters/GetStageChannel.java
+++ b/src/main/java/net/itsthesky/disky/elements/getters/GetStageChannel.java
@@ -3,7 +3,7 @@ package net.itsthesky.disky.elements.getters;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import net.itsthesky.disky.core.Bot;
 import net.dv8tion.jda.api.entities.channel.concrete.StageChannel;

--- a/src/main/java/net/itsthesky/disky/elements/getters/GetStageChannel.java
+++ b/src/main/java/net/itsthesky/disky/elements/getters/GetStageChannel.java
@@ -3,6 +3,7 @@ package net.itsthesky.disky.elements.getters;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import net.itsthesky.disky.core.Bot;
 import net.dv8tion.jda.api.entities.channel.concrete.StageChannel;
@@ -14,6 +15,7 @@ import org.jetbrains.annotations.NotNull;
         "This expression cannot be changed."})
 @Examples("stage channel with id \"000\"")
 @Since("4.0.0")
+@SeeAlso(StageChannel.class)
 public class GetStageChannel extends BaseGetterExpression<StageChannel> {
 
     static {

--- a/src/main/java/net/itsthesky/disky/elements/getters/GetSticker.java
+++ b/src/main/java/net/itsthesky/disky/elements/getters/GetSticker.java
@@ -4,6 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
@@ -29,6 +30,7 @@ import java.util.stream.Collectors;
         "This expression cannot be changed"})
 @Examples({"sticker with named \"meliodas\" from event-guild"})
 @Since("4.9.0")
+@SeeAlso({Guild.class, GuildSticker.class, Sticker.class})
 public class GetSticker extends SimpleExpression<Sticker> implements IAsyncGettableExpression<Sticker> {
 
     static {

--- a/src/main/java/net/itsthesky/disky/elements/getters/GetSticker.java
+++ b/src/main/java/net/itsthesky/disky/elements/getters/GetSticker.java
@@ -4,7 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;

--- a/src/main/java/net/itsthesky/disky/elements/getters/GetTextChannel.java
+++ b/src/main/java/net/itsthesky/disky/elements/getters/GetTextChannel.java
@@ -3,7 +3,7 @@ package net.itsthesky.disky.elements.getters;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import net.itsthesky.disky.core.Bot;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;

--- a/src/main/java/net/itsthesky/disky/elements/getters/GetTextChannel.java
+++ b/src/main/java/net/itsthesky/disky/elements/getters/GetTextChannel.java
@@ -3,6 +3,7 @@ package net.itsthesky.disky.elements.getters;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import net.itsthesky.disky.core.Bot;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
@@ -14,6 +15,7 @@ import org.jetbrains.annotations.NotNull;
         "This expression cannot be changed."})
 @Examples("text channel with id \"000\"")
 @Since("4.0.0")
+@SeeAlso(TextChannel.class)
 public class GetTextChannel extends BaseGetterExpression<TextChannel> {
 
     static {

--- a/src/main/java/net/itsthesky/disky/elements/getters/GetThread.java
+++ b/src/main/java/net/itsthesky/disky/elements/getters/GetThread.java
@@ -3,7 +3,7 @@ package net.itsthesky.disky.elements.getters;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import net.itsthesky.disky.core.Bot;
 import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;

--- a/src/main/java/net/itsthesky/disky/elements/getters/GetThread.java
+++ b/src/main/java/net/itsthesky/disky/elements/getters/GetThread.java
@@ -3,6 +3,7 @@ package net.itsthesky.disky.elements.getters;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import net.itsthesky.disky.core.Bot;
 import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
@@ -14,6 +15,7 @@ import org.jetbrains.annotations.NotNull;
         "This expression cannot be changed."})
 @Examples("thread with id \"000\"")
 @Since("4.0.0")
+@SeeAlso(ThreadChannel.class)
 public class GetThread extends BaseGetterExpression<ThreadChannel> {
 
     static {

--- a/src/main/java/net/itsthesky/disky/elements/getters/GetTimeBoosted.java
+++ b/src/main/java/net/itsthesky/disky/elements/getters/GetTimeBoosted.java
@@ -3,7 +3,7 @@ package net.itsthesky.disky.elements.getters;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
 import ch.njol.skript.util.Date;

--- a/src/main/java/net/itsthesky/disky/elements/getters/GetTimeBoosted.java
+++ b/src/main/java/net/itsthesky/disky/elements/getters/GetTimeBoosted.java
@@ -3,6 +3,7 @@ package net.itsthesky.disky.elements.getters;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.expressions.base.SimplePropertyExpression;
 import ch.njol.skript.util.Date;
@@ -20,6 +21,7 @@ import java.time.OffsetDateTime;
         "This expression cannot be changed."
 })
 @Since("4.0.0")
+@SeeAlso(Member.class)
 public class GetTimeBoosted extends SimplePropertyExpression<Member, Date> {
 
     static {

--- a/src/main/java/net/itsthesky/disky/elements/getters/GetUser.java
+++ b/src/main/java/net/itsthesky/disky/elements/getters/GetUser.java
@@ -3,6 +3,7 @@ package net.itsthesky.disky.elements.getters;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import net.itsthesky.disky.core.Bot;
 import net.dv8tion.jda.api.entities.User;
@@ -15,6 +16,7 @@ import org.jetbrains.annotations.NotNull;
         "This expression cannot be changed."})
 @Examples("user with id \"000\"")
 @Since("4.0.0")
+@SeeAlso({User.class, TextChannel.class})
 public class GetUser extends BaseGetterExpression<User> {
 
     static {

--- a/src/main/java/net/itsthesky/disky/elements/getters/GetUser.java
+++ b/src/main/java/net/itsthesky/disky/elements/getters/GetUser.java
@@ -3,7 +3,7 @@ package net.itsthesky.disky.elements.getters;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import net.itsthesky.disky.core.Bot;
 import net.dv8tion.jda.api.entities.User;

--- a/src/main/java/net/itsthesky/disky/elements/getters/GetUserInGuild.java
+++ b/src/main/java/net/itsthesky/disky/elements/getters/GetUserInGuild.java
@@ -4,6 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
@@ -26,6 +27,7 @@ import org.jetbrains.annotations.Nullable;
 "User can have multiple instance according to which guild they are in, therefore they are considered as member."})
 @Examples("event-user in event-guild")
 @Since("4.0.0")
+@SeeAlso({Guild.class, Member.class, User.class})
 public class GetUserInGuild extends SimpleExpression<Member> implements IAsyncGettableExpression<Member> {
 
 	static {

--- a/src/main/java/net/itsthesky/disky/elements/getters/GetUserInGuild.java
+++ b/src/main/java/net/itsthesky/disky/elements/getters/GetUserInGuild.java
@@ -4,7 +4,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;

--- a/src/main/java/net/itsthesky/disky/elements/getters/GetVoiceChannel.java
+++ b/src/main/java/net/itsthesky/disky/elements/getters/GetVoiceChannel.java
@@ -3,7 +3,7 @@ package net.itsthesky.disky.elements.getters;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import net.itsthesky.disky.core.Bot;
 import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel;

--- a/src/main/java/net/itsthesky/disky/elements/getters/GetVoiceChannel.java
+++ b/src/main/java/net/itsthesky/disky/elements/getters/GetVoiceChannel.java
@@ -3,6 +3,7 @@ package net.itsthesky.disky.elements.getters;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import net.itsthesky.disky.core.Bot;
 import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel;
@@ -14,6 +15,7 @@ import org.jetbrains.annotations.NotNull;
         "This expression cannot be changed."})
 @Examples("voice channel with id \"000\"")
 @Since("4.0.0")
+@SeeAlso(VoiceChannel.class)
 public class GetVoiceChannel extends BaseGetterExpression<VoiceChannel> {
 
     static {

--- a/src/main/java/net/itsthesky/disky/elements/getters/NewFileUpload.java
+++ b/src/main/java/net/itsthesky/disky/elements/getters/NewFileUpload.java
@@ -22,7 +22,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.classes.Changer;
 import ch.njol.skript.config.Node;

--- a/src/main/java/net/itsthesky/disky/elements/getters/NewFileUpload.java
+++ b/src/main/java/net/itsthesky/disky/elements/getters/NewFileUpload.java
@@ -22,6 +22,7 @@ import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.classes.Changer;
 import ch.njol.skript.config.Node;
@@ -53,6 +54,7 @@ import java.util.ArrayList;
         "set {_upload} to file upload from url \"https://example.com/image.png\" with name \"custom.png\"",
         "set {_upload} to file upload from attachment {_attachment} with spoiler true"})
 @Since("4.0.0")
+@SeeAlso(Message.class)
 public class NewFileUpload extends SimpleExpression<FileUpload> {
 
     static {

--- a/src/main/java/net/itsthesky/disky/elements/sections/EmbedSection.java
+++ b/src/main/java/net/itsthesky/disky/elements/sections/EmbedSection.java
@@ -4,6 +4,7 @@ import ch.njol.skript.config.SectionNode;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -21,6 +22,7 @@ import java.util.List;
 @Name("Embed Builder")
 @Description("This builder allow you to make embed easily. You can specify the template used, you must register this template before use it!")
 @Since("3.0")
+@SeeAlso(EmbedBuilder.class)
 @Examples("discord command embed:\n" +
         "    prefixes: !\n" +
         "    trigger:\n" +

--- a/src/main/java/net/itsthesky/disky/elements/sections/EmbedSection.java
+++ b/src/main/java/net/itsthesky/disky/elements/sections/EmbedSection.java
@@ -4,7 +4,7 @@ import ch.njol.skript.config.SectionNode;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;

--- a/src/main/java/net/itsthesky/disky/elements/sections/FindMemberSection.java
+++ b/src/main/java/net/itsthesky/disky/elements/sections/FindMemberSection.java
@@ -7,6 +7,7 @@ import ch.njol.skript.config.SectionNode;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.effects.Delay;
 import ch.njol.skript.lang.*;
@@ -43,6 +44,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
         "\treturn true",
         "reply with \"I have found %size of {_members::*}% that has the role and is muted!\""})
 @Since("4.14.3")
+@SeeAlso({Member.class, Guild.class})
 public class FindMemberSection extends Section {
 
     static {

--- a/src/main/java/net/itsthesky/disky/elements/sections/FindMemberSection.java
+++ b/src/main/java/net/itsthesky/disky/elements/sections/FindMemberSection.java
@@ -7,7 +7,7 @@ import ch.njol.skript.config.SectionNode;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.effects.Delay;
 import ch.njol.skript.lang.*;

--- a/src/main/java/net/itsthesky/disky/elements/sections/ReactSection.java
+++ b/src/main/java/net/itsthesky/disky/elements/sections/ReactSection.java
@@ -5,6 +5,7 @@ import ch.njol.skript.config.SectionNode;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
+import ch.njol.skript.doc.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.*;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
@@ -27,6 +28,7 @@ import java.util.List;
 @Examples({"react to event-message with reaction \"joy\" to run:",
         "\treply with \"You clicked the reaction!\""})
 @Since("4.0.0")
+@SeeAlso(Message.class)
 public class ReactSection extends EffectSection {
 
 	static {

--- a/src/main/java/net/itsthesky/disky/elements/sections/ReactSection.java
+++ b/src/main/java/net/itsthesky/disky/elements/sections/ReactSection.java
@@ -5,7 +5,7 @@ import ch.njol.skript.config.SectionNode;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
 import ch.njol.skript.doc.Name;
-import ch.njol.skript.doc.SeeAlso;
+import net.itsthesky.disky.api.generator.SeeAlso;
 import ch.njol.skript.doc.Since;
 import ch.njol.skript.lang.*;
 import ch.njol.skript.lang.SkriptParser.ParseResult;


### PR DESCRIPTION
## Summary

This PR completes the documentation enhancement for DiSky by:
1. ✅ Adding full documentation to previously undocumented elements
2. ✅ Adding `@SeeAlso` annotations to **all** elements (conditions, effects, sections, expressions)

## Changes Overview

### Phase 1: Document Missing Elements (Commit 2f9a171)
- **AwaitEffect.java** - Added @Name, @Description, @Examples, @Since
- **RetrieveEventValue.java** - Added @Name, @Description, @Examples, @Since  
- **BaseGetterExpression.java** - Added @Name, @Description, @Examples, @Since

### Phase 2: Add @SeeAlso Annotations (Commit 745d4ab)

#### Conditions (9 files)
- BotMemberIsInThread → References `Member.class`, `ThreadChannel.class`
- HasPermissions → References `Member.class`, `Permission.class`, `GuildChannel.class`
- HasRole → References `Member.class`, `Role.class`
- IsBot, IsDeafen, IsMuted, IsTimeout → Reference `Member.class` or `User.class`
- MessageOrigin → References `Message.class`
- isInline → References `MessageEmbed.Field.class`

#### Sections (3 files)
- EmbedSection → References `EmbedBuilder.class`
- FindMemberSection → References `Member.class`, `Guild.class`
- ReactSection → References `Message.class`

#### Effects (32 files)
All effects now have `@SeeAlso` annotations referencing relevant JDA entities:
- Channel operations: `ThreadChannel`, `ForumChannel`, `AudioChannel`, etc.
- Member operations: `Member`, `Guild`, `Role`
- Message operations: `Message`, `MessageChannel`
- Interaction operations: `IReplyCallback`, `ComponentInteraction`

#### Expressions/Getters (22 files)
All getters now reference their corresponding JDA entity types:
- GetGuild → `Guild.class`
- GetMember → `Member.class`
- GetTextChannel, GetVoiceChannel, etc. → Respective channel classes
- GetRole → `Role.class`
- GetUser → `User.class`
