### PR TITLE
Fix MemberNickname class

### DIFF
--- a/src/main/java/net/itsthesky/disky/elements/properties/members/MemberNickname.java
+++ b/src/main/java/net/itsthesky/disky/elements/properties/members/MemberNickname.java
@@ -50,8 +50,7 @@ public class MemberNickname extends MemberProperty<String>
             return;
         final Member member = EasyElement.parseSingle(getExpr(), e, null);
         final String name = (String) delta[0];
-        if (EasyElement.anyNull(this, member, name))
-            return;
+        if ((mode != Changer.ChangeMode.RESET && mode != Changer.ChangeMode.DELETE) && EasyElement.anyNull(this, name)) return;
 
         if (!member.getGuild().getSelfMember().canInteract(member)) {
             DiSky.getInstance().getLogger()


### PR DESCRIPTION
This PR fixes an issue where you are unable to reset (or clear) a user's nickname, causing you to use `{_member}.modifyNickname(null).queue()` to clear it.