### PR TITLE
⚡Allow Resetting or Clearing of a Nickname

### DIFF
--- a/src/main/java/net/itsthesky/disky/elements/properties/members/MemberNickname.java
+++ b/src/main/java/net/itsthesky/disky/elements/properties/members/MemberNickname.java
@@ -40,7 +40,7 @@ public class MemberNickname extends MemberProperty<String>
 
     @Override
     public Class<?> @NotNull [] acceptChange(@NotNull Changer.ChangeMode mode) {
-        if (EasyElement.equalAny(mode, Changer.ChangeMode.SET, Changer.ChangeMode.RESET))
+        if (EasyElement.equalAny(mode, Changer.ChangeMode.SET, Changer.ChangeMode.RESET, Changer.ChangeMode.DELETE))
             return new Class[] {String.class};
         return new Class[0];
     }
@@ -50,7 +50,9 @@ public class MemberNickname extends MemberProperty<String>
             return;
         final Member member = EasyElement.parseSingle(getExpr(), e, null);
         final String name = (String) delta[0];
-        if ((mode != Changer.ChangeMode.RESET && mode != Changer.ChangeMode.DELETE) && EasyElement.anyNull(this, member, name))
+        if ((mode != Changer.ChangeMode.RESET && mode != Changer.ChangeMode.DELETE) && EasyElement.anyNull(this, member))
+            return;
+        if (mode != Changer.ChangeMode.RESET && mode != Changer.ChangeMode.DELETE && name == null)
             return;
 
         if (!member.getGuild().getSelfMember().canInteract(member)) {

--- a/src/main/java/net/itsthesky/disky/elements/properties/members/MemberNickname.java
+++ b/src/main/java/net/itsthesky/disky/elements/properties/members/MemberNickname.java
@@ -50,7 +50,7 @@ public class MemberNickname extends MemberProperty<String>
             return;
         final Member member = EasyElement.parseSingle(getExpr(), e, null);
         final String name = (String) delta[0];
-        if (EasyElement.anyNull(this, member, name))
+        if ((mode != Changer.ChangeMode.RESET && mode != Changer.ChangeMode.DELETE) && EasyElement.anyNull(this, member, name))
             return;
 
         if (!member.getGuild().getSelfMember().canInteract(member)) {

--- a/src/main/java/net/itsthesky/disky/elements/properties/members/MemberNickname.java
+++ b/src/main/java/net/itsthesky/disky/elements/properties/members/MemberNickname.java
@@ -50,7 +50,7 @@ public class MemberNickname extends MemberProperty<String>
             return;
         final Member member = EasyElement.parseSingle(getExpr(), e, null);
         final String name = (String) delta[0];
-        if ((mode != Changer.ChangeMode.RESET && mode != Changer.ChangeMode.DELETE) && EasyElement.anyNull(this, member))
+        if (EasyElement.anyNull(this, member))
             return;
         if (mode != Changer.ChangeMode.RESET && mode != Changer.ChangeMode.DELETE && name == null)
             return;


### PR DESCRIPTION
As the title states, This fixes an issue where you are unable to reset (or clear) a user's nickname, causing you to use `{_member}.modifyNickname(null).queue()` to clear it, which addresses #290 