### PR TITLE
enhance `FindMember` section with native `EffReturn` support

### DIFF
--- a/src/main/java/net/itsthesky/disky/elements/sections/FindMemberSection.java
+++ b/src/main/java/net/itsthesky/disky/elements/sections/FindMemberSection.java
@@ -42,7 +42,7 @@ import java.util.List;
         "reply with \"I have found %size of {_members::*}% that has the role and is muted!\""})
 @Since("4.14.3")
 @SeeAlso({Member.class, Guild.class})
-public class FindMemberSection extends Section implements ReturnHandler<Member> {
+public class FindMemberSection extends Section implements ReturnHandler<Boolean> {
 
     public static @Nullable FindMemberSection instance;
 
@@ -51,18 +51,14 @@ public class FindMemberSection extends Section implements ReturnHandler<Member> 
                 FindMemberSection.class,
                 "find [the] [discord] member[s] (in|from) [guild] %guild% and store (them|the members) in %~objects% with filter var[iable] %~objects%"
         );
-
-        Skript.registerEffect(
-                EffReturn.class,
-                "return %objects%"
-        );
     }
 
     private Expression<Guild> exprGuild;
     private Expression<Object> exprResult;
     private Expression<Object> exprValue;
 
-    private ReturnableTrigger<Member> trigger;
+    private ReturnableTrigger<Boolean> trigger;
+    private boolean iterationResult = false;
 
     @Override
     public boolean init(Expression<?>[] expressions, int matchedPattern, @NotNull Kleenean isDelayed, @NotNull ParseResult parseResult, @NotNull SectionNode sectionNode, @NotNull List<TriggerItem> triggerItems) {
@@ -88,18 +84,19 @@ public class FindMemberSection extends Section implements ReturnHandler<Member> 
     }
 
     @Override
-    public void returnValues(Event event, Expression<? extends Member> value) {
-
+    public void returnValues(Event event, Expression<? extends Boolean> value) {
+        Boolean returned = value.getSingle(event);
+        iterationResult = returned != null && returned;
     }
 
     @Override
     public boolean isSingleReturnValue() {
-        return false;
+        return true;
     }
 
     @Override
-    public @Nullable Class<? extends Member> returnValueType() {
-        return Member.class;
+    public @Nullable Class<? extends Boolean> returnValueType() {
+        return Boolean.class;
     }
 
     @Override
@@ -123,10 +120,12 @@ public class FindMemberSection extends Section implements ReturnHandler<Member> 
             try {
 
                 List<Member> members = guild.findMembers(member -> {
-                    exprValue.change(e, new Member[]{member}, Changer.ChangeMode.SET);
+
+                    iterationResult = false;
+                    exprValue.change(e, new Member[] {member}, Changer.ChangeMode.SET);
 
                     TriggerItem.walk(trigger, e);
-                    return false;
+                    return iterationResult;
                 }).get();
 
                 exprResult.change(e, members.toArray(new Member[0]), Changer.ChangeMode.SET);
@@ -160,115 +159,5 @@ public class FindMemberSection extends Section implements ReturnHandler<Member> 
     @Override
     public @NotNull String toString(@Nullable Event event, boolean debug) {
         return "find members in guild " + exprGuild.toString(event, debug) + " and store them in " + exprResult.toString(event, debug) + " with filter " + exprValue.toString(event, debug);
-    }
-
-    // ####################################################################################################
-
-    public static class EffReturn extends Effect {
-
-        @SuppressWarnings("NotNullFieldNotInitialized")
-        private ScriptFunction<?> function;
-
-        @SuppressWarnings("NotNullFieldNotInitialized")
-        private Expression<?> value;
-        private @Nullable FindMemberSection section;
-
-        @SuppressWarnings("unchecked")
-        @Override
-        public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, ParseResult parseResult) {
-            if (instance != null) {
-                section = instance;
-                value = exprs[0];
-                return true;
-            }
-
-            ScriptFunction<?> f = Functions.currentFunction;
-            if (f == null) {
-                Skript.error("The return statement can only be used in a function");
-                return false;
-            }
-
-            if (!isDelayed.isFalse()) {
-                Skript.error("A return statement after a delay is useless, as the calling trigger will resume when the delay starts (and won't get any returned value)");
-                return false;
-            }
-
-            function = f;
-            ClassInfo<?> returnType = function.getReturnType();
-            if (returnType == null) {
-                Skript.error("This function doesn't return any value. Please use 'stop' or 'exit' if you want to stop the function.");
-                return false;
-            }
-
-            RetainingLogHandler log = SkriptLogger.startRetainingLog();
-            Expression<?> convertedExpr;
-            try {
-                convertedExpr = exprs[0].getConvertedExpression(returnType.getC());
-                if (convertedExpr == null) {
-                    log.printErrors("This function is declared to return " + returnType.getName().withIndefiniteArticle() + ", but " + exprs[0].toString(null, false) + " is not of that type.");
-                    return false;
-                }
-                log.printLog();
-            } finally {
-                log.stop();
-            }
-
-            if (f.isSingle() && !convertedExpr.isSingle()) {
-                Skript.error("This function is defined to only return a single " + returnType.toString() + ", but this return statement can return multiple values.");
-                return false;
-            }
-            value = convertedExpr;
-
-            return true;
-        }
-
-        @Override
-        @Nullable
-        @SuppressWarnings({"unchecked", "rawtypes"})
-        protected TriggerItem walk(Event event) {
-            debug(event, false);
-
-            if (section != null) {
-                try {
-//                    section.iterationResult = value.getSingle(event) != null && Boolean.TRUE.equals(value.getSingle(event));
-                } catch (Exception e) {
-                    Expression<?> converted = value.getConvertedExpression(Boolean.class);
-                    if (converted == null) {
-                        Skript.error("Cannot convert the value to a boolean: " + value.toString(event, false));
-                        return null;
-                    }
-
-//                    section.iterationResult = converted.getSingle(event) != null && Boolean.TRUE.equals(converted.getSingle(event));
-                }
-                return null;
-            }
-
-            if (event instanceof FunctionEvent) {
-                ((ScriptFunction) function).returnValues(event, value);
-            } else {
-                assert false : event;
-            }
-
-            TriggerSection parent = getParent();
-            while (parent != null) {
-                if (parent instanceof LoopSection)
-                    ((LoopSection) parent).exit(event);
-
-                parent = parent.getParent();
-            }
-
-            return null;
-        }
-
-        @Override
-        protected void execute(Event event) {
-            assert false;
-        }
-
-        @Override
-        public String toString(@Nullable Event event, boolean debug) {
-            return "return " + value.toString(event, debug);
-        }
-
     }
 }


### PR DESCRIPTION
This PR aims to fix #294 (or at least enhance it) with the new return system introduced in Skript 2.9.
As i can't fina ny suitable exmaple or documentation on this, I am struggling in adding this support in the current effect. Especially, I can't find how to:

- Handle the different iterations of the section's code (in my case I repeat the same Skript code of the section, with a different value each time, then handle the result of that specific iteration)
- Handle the "filtered" values (based on the return value of each iterations)
- Handle delays inside the section (`afterLoading` consumer is not available anymore using `loadReturnableSectionCode`, so how do I do that)

Thanks to @sovdeeth for the report, and pointing out what to use (although I have no idea how to do so).